### PR TITLE
fix: standardize setter naming to camelCase in tracker.tsx

### DIFF
--- a/app/tracker.tsx
+++ b/app/tracker.tsx
@@ -32,9 +32,9 @@ export default function TrackerScreen() {
 
   const { updateAndroidWidget } = useUpdateAndroidWidget();
 
-  const [dailyTrackerGoalValue, setdailyTrackerGoalValue] =
+  const [dailyTrackerGoalValue, setDailyTrackerGoalValue] =
     useAtom(dailyTrackerGoal);
-  const [dailyTrackerCompletedValue, setdailyTrackerCompletedValue] = useAtom(
+  const [dailyTrackerCompletedValue, setDailyTrackerCompletedValue] = useAtom(
     dailyTrackerCompleted,
   );
   const [yesterdayPageValue, setYesterdayPageValue] = useAtom(yesterdayPage);
@@ -51,9 +51,9 @@ export default function TrackerScreen() {
       : 0;
 
   // Should change by full hizb (8 thumns)
-  const incrementDailyGoal = () => setdailyTrackerGoalValue((prev) => prev + 1);
+  const incrementDailyGoal = () => setDailyTrackerGoalValue((prev) => prev + 1);
   const decrementDailyGoal = () =>
-    setdailyTrackerGoalValue((prev) => Math.max(1, prev - 1));
+    setDailyTrackerGoalValue((prev) => Math.max(1, prev - 1));
 
   // Consolidated reset logic into one function
   const performReset = async () => {
@@ -64,7 +64,7 @@ export default function TrackerScreen() {
       });
     }
 
-    setdailyTrackerCompletedValue({
+    setDailyTrackerCompletedValue({
       value: 0,
       date: new Date().toDateString(),
     });


### PR DESCRIPTION
## Summary
- Renamed `setdailyTrackerGoalValue` → `setDailyTrackerGoalValue`
- Renamed `setdailyTrackerCompletedValue` → `setDailyTrackerCompletedValue`

Both setter functions were missing the capital 'T' after `set`, breaking the standard React `[value, setValue]` camelCase convention.

## Changes
- `app/tracker.tsx` — 5 occurrences renamed (2 declarations + 3 usages)

Closes #30

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved internal naming consistency for code variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->