### PR TITLE
feat: add Rate on Store button

### DIFF
--- a/app/(tabs)/(more)/index.tsx
+++ b/app/(tabs)/(more)/index.tsx
@@ -19,6 +19,7 @@ import MailSVG from '@/assets/svgs/mail.svg';
 import PageSVG from '@/assets/svgs/page.svg';
 import SettingsSVG from '@/assets/svgs/settings.svg';
 import ShareSVG from '@/assets/svgs/share.svg';
+import StarSVG from '@/assets/svgs/star.svg';
 import WelcomeSVG from '@/assets/svgs/welcome.svg';
 import { ThemedButton } from '@/components/ThemedButton';
 import { ThemedText } from '@/components/ThemedText';
@@ -131,6 +132,25 @@ export default function MoreScreen() {
         <View style={styles.buttonContent}>
           <ShareSVG width={24} height={24} style={styles.svg} />
           <Text style={styles.buttonText}>شارك التطبيق</Text>
+        </View>
+      </ThemedButton>
+      <ThemedButton
+        onPress={async () => {
+          const url =
+            Platform.OS === 'android'
+              ? 'https://play.google.com/store/apps/details?id=com.adelpro.openmushafnative'
+              : 'https://www.quran.us.kg';
+          const supported = await Linking.canOpenURL(url);
+          if (supported) {
+            await Linking.openURL(url);
+          }
+        }}
+        variant="primary"
+        style={styles.button}
+      >
+        <View style={styles.buttonContent}>
+          <StarSVG width={24} height={24} style={styles.svg} />
+          <Text style={styles.buttonText}>قيّم التطبيق</Text>
         </View>
       </ThemedButton>
 

--- a/assets/svgs/star.svg
+++ b/assets/svgs/star.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+  <title>star</title>
+  <desc id="desc">
+    star
+  </desc>
+  <g fill="none" stroke="currentColor" stroke-width="1.5">
+    <path stroke-linecap="round" stroke-linejoin="round"
+      d="M12 2l3.09 6.26L22 9.27l-5 4.87l1.18 6.88L12 17.77l-6.18 3.25L7 14.14L2 9.27l6.91-1.01z" />
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
- Adds a "قيّم التطبيق" (Rate on Store) button to the More menu
- Opens the Play Store listing on Android devices
- Falls back to the app website (quran.us.kg) on other platforms
- Uses a new star SVG icon consistent with other menu icons
- Follows the existing `Linking.canOpenURL` / `Linking.openURL` pattern

## Changes
- `app/(tabs)/(more)/index.tsx`: Added Rate on Store button after Share button
- `assets/svgs/star.svg`: New star icon matching the existing SVG style

Closes #29