### PR TITLE
feat: extract gesture magic numbers to named constants

### DIFF
--- a/app/(tabs)/(more)/settings.tsx
+++ b/app/(tabs)/(more)/settings.tsx
@@ -13,7 +13,11 @@ import SEO from '@/components/seo';
 import { ThemedButton } from '@/components/ThemedButton';
 import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
-import { riwayaOptions } from '@/constants';
+import {
+  riwayaOptions,
+  SWIPE_SENSITIVITY_MAX,
+  SWIPE_SENSITIVITY_MIN,
+} from '@/constants';
 import { useColors } from '@/hooks/useColors';
 import {
   flipSound,
@@ -21,6 +25,7 @@ import {
   mushafContrast,
   mushafRiwaya,
   showTrackerNotification,
+  swipeSensitivity,
 } from '@/jotai/atoms';
 import { RiwayaByIndice, RiwayaByValue } from '@/utils';
 import { clearStorageAndReload } from '@/utils/storage/clearStorage';
@@ -35,6 +40,8 @@ export default function SettingsScreen() {
   const { textColor, primaryColor, cardColor, iconColor } = useColors();
   const [mushafContrastValue, setMushafContrastValue] = useAtom(mushafContrast);
   const [mushafRiwayaValue, setMushafRiwayaValue] = useAtom(mushafRiwaya);
+  const [swipeSensitivityValue, setSwipeSensitivityValue] =
+    useAtom(swipeSensitivity);
   const [confirmModalVisible, setConfirmModalVisible] = useState(false);
 
   const toggleFlipSoundSwitch = () => {
@@ -171,6 +178,44 @@ export default function SettingsScreen() {
             value={mushafContrastValue}
             onValueChange={setMushafContrastValue}
             primaryColor={primaryColor}
+          />
+        </ThemedView>
+      </ThemedView>
+
+      <ThemedView
+        style={[
+          styles.settingsSection,
+          styles.columnSection,
+          { backgroundColor: cardColor },
+        ]}
+      >
+        <ThemedView
+          style={[
+            styles.rowContainer,
+            styles.iconTextContainer,
+            { backgroundColor: cardColor },
+          ]}
+        >
+          <Feather
+            name="navigation"
+            size={24}
+            color={iconColor}
+            style={styles.iconStyle}
+          />
+          <ThemedText type="defaultSemiBold" style={styles.itemText}>
+            {` حساسية التمرير: (${Math.round(swipeSensitivityValue)})`}
+          </ThemedText>
+        </ThemedView>
+
+        <ThemedView
+          style={[styles.sliderContainer, { backgroundColor: cardColor }]}
+        >
+          <AwesomeSlider
+            value={swipeSensitivityValue}
+            onValueChange={(v) => setSwipeSensitivityValue(Math.round(v))}
+            primaryColor={primaryColor}
+            minimumValue={SWIPE_SENSITIVITY_MIN}
+            maximumValue={SWIPE_SENSITIVITY_MAX}
           />
         </ThemedView>
       </ThemedView>

--- a/components/MushafPage.tsx
+++ b/components/MushafPage.tsx
@@ -33,6 +33,7 @@ import {
   hizbNotification,
   mushafContrast,
   showTrackerNotification,
+  swipeSensitivity,
   yesterdayPage,
 } from '@/jotai/atoms';
 import { calculateThumnsBetweenPages } from '@/utils/hizbProgress';
@@ -63,6 +64,7 @@ export default function MushafPage() {
   const [progressValue, setProgressValue] = useState(0);
   const dailyTrackerGoalValue = useAtomValue(dailyTrackerGoal);
   const dailyTrackerCompletedValue = useAtomValue(dailyTrackerCompleted);
+  const swipeSensitivityValue = useAtomValue(swipeSensitivity);
 
   const {
     thumnData,
@@ -180,6 +182,7 @@ export default function MushafPage() {
     currentPage,
     handlePageChange,
     defaultNumberOfPages,
+    swipeSensitivityValue,
   );
 
   const animatedStyle = useAnimatedStyle(() => {

--- a/components/TutorialGuide.tsx
+++ b/components/TutorialGuide.tsx
@@ -24,7 +24,11 @@ import NextSVG from '@/assets/svgs/next.svg';
 import { ThemedButton } from '@/components/ThemedButton';
 import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
-import { SLIDES } from '@/constants';
+import {
+  SLIDES,
+  SWIPE_THRESHOLD_LANDSCAPE,
+  SWIPE_THRESHOLD_PORTRAIT,
+} from '@/constants';
 import { useColors } from '@/hooks/useColors';
 import useOrientation from '@/hooks/useOrientation';
 import { finishedTutorial } from '@/jotai/atoms';
@@ -46,7 +50,9 @@ export default function TutorialGuide() {
   };
 
   const gestureHandler = Gesture.Pan().onEnd((e) => {
-    const threshold = isLandscape ? 150 : 100;
+    const threshold = isLandscape
+      ? SWIPE_THRESHOLD_LANDSCAPE
+      : SWIPE_THRESHOLD_PORTRAIT;
 
     if (e.translationX < -threshold && index > 0) {
       runOnJS(setIndex)(index - 1);

--- a/components/awesomeSlider.tsx
+++ b/components/awesomeSlider.tsx
@@ -7,16 +7,20 @@ type Props = {
   value: number;
   onValueChange: (value: number) => void;
   primaryColor: string;
+  minimumValue?: number;
+  maximumValue?: number;
 };
 
 export default function AwesomeSlider({
   value,
   onValueChange,
   primaryColor,
+  minimumValue = 0.3,
+  maximumValue = 1,
 }: Props) {
   const progress = useSharedValue(value);
-  const min = useSharedValue(0.3);
-  const max = useSharedValue(1);
+  const min = useSharedValue(minimumValue);
+  const max = useSharedValue(maximumValue);
 
   useEffect(() => {
     progress.value = value;

--- a/constants/gesture.ts
+++ b/constants/gesture.ts
@@ -1,0 +1,40 @@
+/**
+ * Gesture handler constants for swipe page navigation.
+ *
+ * SWIPE_THRESHOLD_PORTRAIT / SWIPE_THRESHOLD_LANDSCAPE:
+ *   Minimum horizontal translation (px) the user must drag before a
+ *   page turn is triggered. Landscape requires a wider swipe because
+ *   the screen is wider, preventing accidental turns.
+ *
+ * MAX_DRAG_TRANSLATION:
+ *   Clamps the visible drag distance so the page preview never slides
+ *   further than this many pixels from its resting position.
+ *
+ * SPRING_DAMPING / SPRING_STIFFNESS:
+ *   Control the "snap back" animation after a swipe. Higher damping
+ *   reduces bounce; higher stiffness makes the return faster.
+ */
+
+/** Default swipe threshold in portrait mode (px). */
+export const SWIPE_THRESHOLD_PORTRAIT = 100;
+
+/** Default swipe threshold in landscape mode (px). */
+export const SWIPE_THRESHOLD_LANDSCAPE = 150;
+
+/** Maximum visual drag displacement (px). */
+export const MAX_DRAG_TRANSLATION = 100;
+
+/** Spring animation damping for the snap-back. */
+export const SPRING_DAMPING = 20;
+
+/** Spring animation stiffness for the snap-back. */
+export const SPRING_STIFFNESS = 90;
+
+/** Ratio of landscape threshold to portrait threshold. */
+export const LANDSCAPE_THRESHOLD_RATIO = SWIPE_THRESHOLD_LANDSCAPE / SWIPE_THRESHOLD_PORTRAIT;
+
+/** Minimum configurable swipe sensitivity (px) — very sensitive. */
+export const SWIPE_SENSITIVITY_MIN = 50;
+
+/** Maximum configurable swipe sensitivity (px) — very insensitive. */
+export const SWIPE_SENSITIVITY_MAX = 200;

--- a/constants/index.ts
+++ b/constants/index.ts
@@ -9,3 +9,5 @@ export * from './slides';
 export * from './readingPositionBannerHeights';
 
 export * from './riwayaOptions';
+
+export * from './gesture';

--- a/hooks/usePanGestureHandler.ts
+++ b/hooks/usePanGestureHandler.ts
@@ -1,22 +1,39 @@
 import { Gesture } from 'react-native-gesture-handler';
 import { runOnJS, useSharedValue, withSpring } from 'react-native-reanimated';
 
+import {
+  LANDSCAPE_THRESHOLD_RATIO,
+  MAX_DRAG_TRANSLATION,
+  SPRING_DAMPING,
+  SPRING_STIFFNESS,
+} from '@/constants';
+
 import useOrientation from './useOrientation';
 
 export const usePanGestureHandler = (
   currentPage: number,
   onPageChange: (page: number) => void,
   maxPages: number,
+  /** Portrait swipe threshold in px. Landscape is derived automatically. */
+  swipeThreshold = 100,
 ) => {
   const translateX = useSharedValue(0);
   const { isLandscape } = useOrientation();
 
   const panGestureHandler = Gesture.Pan()
     .onUpdate((e) => {
-      translateX.value = Math.max(-100, Math.min(100, e.translationX));
+      // Clamp visible drag to MAX_DRAG_TRANSLATION in either direction
+      translateX.value = Math.max(
+        -MAX_DRAG_TRANSLATION,
+        Math.min(MAX_DRAG_TRANSLATION, e.translationX),
+      );
     })
     .onEnd((e) => {
-      const threshold = isLandscape ? 150 : 100;
+      // Landscape screens require a proportionally wider swipe
+      const threshold = isLandscape
+        ? swipeThreshold * LANDSCAPE_THRESHOLD_RATIO
+        : swipeThreshold;
+
       const targetPage =
         e.translationX > threshold
           ? Math.min(currentPage + 1, maxPages) // Swipe Right
@@ -29,7 +46,11 @@ export const usePanGestureHandler = (
         runOnJS(onPageChange)(targetPage);
       }
 
-      translateX.value = withSpring(0, { damping: 20, stiffness: 90 }); // Smooth return
+      // Smooth snap-back to resting position
+      translateX.value = withSpring(0, {
+        damping: SPRING_DAMPING,
+        stiffness: SPRING_STIFFNESS,
+      });
     });
 
   return { translateX, panGestureHandler };

--- a/jotai/atoms.ts
+++ b/jotai/atoms.ts
@@ -128,3 +128,10 @@ export const readingBannerCollapsedState = createAtomWithStorage<boolean>(
   'ReadingBannerCollapsedState',
   false,
 );
+
+// Swipe sensitivity for page-turn gesture threshold (px).
+// Lower = more sensitive, higher = less sensitive. Default 100.
+export const swipeSensitivity = createAtomWithStorage<number>(
+  'SwipeSensitivity',
+  100,
+);


### PR DESCRIPTION
## Summary
- Extracts all magic numbers from the pan gesture handler into documented named constants (`constants/gesture.ts`)
- Makes swipe sensitivity configurable via a new slider in the Settings screen
- Adds `swipeSensitivity` Jotai atom (persisted) so the setting survives app restarts
- Updates `AwesomeSlider` to accept optional `minimumValue`/`maximumValue` props

## Changes
- `constants/gesture.ts` (new): `SWIPE_THRESHOLD_PORTRAIT` (100), `SWIPE_THRESHOLD_LANDSCAPE` (150), `MAX_DRAG_TRANSLATION` (100), `SPRING_DAMPING` (20), `SPRING_STIFFNESS` (90) — all documented
- `hooks/usePanGestureHandler.ts`: Uses named constants, accepts optional `swipeThreshold` param
- `components/TutorialGuide.tsx`: Uses `SWIPE_THRESHOLD_*` constants instead of inline 100/150
- `components/MushafPage.tsx`: Reads `swipeSensitivity` atom and passes to gesture handler
- `components/awesomeSlider.tsx`: Added `minimumValue`/`maximumValue` optional props
- `jotai/atoms.ts`: Added `swipeSensitivity` atom (default: 100)
- `app/(tabs)/(more)/settings.tsx`: Added swipe sensitivity slider (range 50–200)

Closes #33