### PR TITLE
feat: add Rate on Store button to More screen

### DIFF
--- a/app/(tabs)/(more)/index.tsx
+++ b/app/(tabs)/(more)/index.tsx
@@ -151,6 +151,25 @@ export default function MoreScreen() {
           <Text style={styles.buttonText}>شارك التطبيق</Text>
         </View>
       </ThemedButton>
+      {Platform.OS === 'android' && (
+        <ThemedButton
+          onPress={async () => {
+            const url =
+              'https://play.google.com/store/apps/details?id=com.adelpro.openmushafnative';
+            const supported = await Linking.canOpenURL(url);
+            if (supported) {
+              await Linking.openURL(url);
+            }
+          }}
+          variant="primary"
+          style={styles.button}
+        >
+          <View style={styles.buttonContent}>
+            <Feather name="star" size={24} color="white" style={styles.svg} />
+            <Text style={styles.buttonText}>قيّم التطبيق</Text>
+          </View>
+        </ThemedButton>
+      )}
 
       {/* Error Modal */}
       <Modal


### PR DESCRIPTION
## Summary
- Added a "قيّم التطبيق" (Rate the App) button in the More screen
- Opens the Google Play Store listing for the app on Android devices
- Uses Feather `star` icon consistent with the existing icon style
- Only renders on Android (hidden on web)

## Changes
- `app/(tabs)/(more)/index.tsx` — added Rate on Store button after Share button

## Test plan
- [ ] Verify button appears on Android
- [ ] Verify tapping opens the Play Store listing
- [ ] Verify button does NOT appear on web
- [ ] Verify layout and styling matches other buttons in the list

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)