### PR TITLE
fix: add accessibility labels to icon-only buttons

### DIFF
--- a/app/(tabs)/(more)/index.tsx
+++ b/app/(tabs)/(more)/index.tsx
@@ -159,6 +159,8 @@ export default function MoreScreen() {
               <TouchableOpacity
                 style={styles.closeButton}
                 onPress={() => setErrorModalVisible(false)}
+                accessibilityRole="button"
+                accessibilityLabel="إغلاق رسالة الخطأ"
               >
                 <Feather name="x" size={24} color={iconColor} />
               </TouchableOpacity>

--- a/app/(tabs)/(more)/settings.tsx
+++ b/app/(tabs)/(more)/settings.tsx
@@ -294,6 +294,8 @@ export default function SettingsScreen() {
               <TouchableOpacity
                 style={styles.closeButton}
                 onPress={() => setConfirmModalVisible(false)}
+                accessibilityRole="button"
+                accessibilityLabel="إغلاق نافذة التأكيد"
               >
                 <Feather name="x" size={24} color={iconColor} />
               </TouchableOpacity>

--- a/app/search.tsx
+++ b/app/search.tsx
@@ -138,7 +138,12 @@ export default function Search() {
           color={primaryColor}
           style={styles.icon}
         />
-        <Pressable onPress={() => setShowOptions(!showOptions)}>
+        <Pressable
+          onPress={() => setShowOptions(!showOptions)}
+          accessibilityRole="button"
+          accessibilityLabel="خيارات البحث المتقدم"
+          accessibilityState={{ expanded: showOptions }}
+        >
           <Ionicons
             name="options"
             size={20}

--- a/app/tracker.tsx
+++ b/app/tracker.tsx
@@ -243,6 +243,8 @@ export default function TrackerScreen() {
                 <TouchableOpacity
                   style={styles.closeButton}
                   onPress={() => setConfirmModalVisible(false)}
+                  accessibilityRole="button"
+                  accessibilityLabel="إغلاق نافذة التأكيد"
                 >
                   <Feather name="x" size={24} color={iconColor} />
                 </TouchableOpacity>

--- a/components/PageNavigator.tsx
+++ b/components/PageNavigator.tsx
@@ -106,6 +106,8 @@ export default function PageNavigator({
             <TouchableOpacity
               style={styles.submitButton}
               onPress={handleInputSubmit}
+              accessibilityRole="button"
+              accessibilityLabel="تأكيد رقم الصفحة"
             >
               <Feather name="check" size={18} color={primaryColor} />
             </TouchableOpacity>

--- a/components/SurahAyaNavigator.tsx
+++ b/components/SurahAyaNavigator.tsx
@@ -178,6 +178,8 @@ export default function SurahAyaNavigator({
               <TouchableOpacity
                 style={styles.closeButton}
                 onPress={() => setSurahModalVisible(false)}
+                accessibilityRole="button"
+                accessibilityLabel="إغلاق قائمة السور"
               >
                 <Feather name="x" size={24} color={iconColor} />
               </TouchableOpacity>
@@ -220,6 +222,8 @@ export default function SurahAyaNavigator({
               <TouchableOpacity
                 style={styles.closeButton}
                 onPress={() => setAyaModalVisible(false)}
+                accessibilityRole="button"
+                accessibilityLabel="إغلاق قائمة الآيات"
               >
                 <Feather name="x" size={24} color={iconColor} />
               </TouchableOpacity>

--- a/components/TopMenu.tsx
+++ b/components/TopMenu.tsx
@@ -128,6 +128,8 @@ export default function TopMenu() {
                 setShowTopMenuState(false);
                 router.push('/tracker');
               }}
+              accessibilityRole="button"
+              accessibilityLabel="الورد اليومي"
             >
               <View style={styles.progressContainer}>
                 <Progress.Circle
@@ -154,6 +156,8 @@ export default function TopMenu() {
               setShowTopMenuState(false);
               router.push('/navigation');
             }}
+            accessibilityRole="button"
+            accessibilityLabel="الانتقال إلى صفحة أو سورة"
           >
             <Ionicons
               name="navigate-circle-outline"
@@ -168,6 +172,8 @@ export default function TopMenu() {
               setShowTopMenuState(false);
               router.push('/search');
             }}
+            accessibilityRole="button"
+            accessibilityLabel="البحث في القرآن"
           >
             <Ionicons name="search" size={ICON_SIZE} color={tintColor} />
           </TouchableOpacity>
@@ -177,6 +183,10 @@ export default function TopMenu() {
               setShowTopMenuState(false);
               toggleMenu();
             }}
+            accessibilityRole="button"
+            accessibilityLabel={
+              showBottomMenuState ? 'وضع ملء الشاشة' : 'إظهار القائمة'
+            }
           >
             {showBottomMenuState ? (
               <MaterialCommunityIcons


### PR DESCRIPTION
## Summary
- Add `accessibilityRole="button"` and Arabic `accessibilityLabel` to 11 icon-only buttons across 7 files
- Ensures screen readers can properly announce button purposes
- All labels are in Arabic to match the app's language

### Files changed:
- `components/TopMenu.tsx` — 4 buttons (tracker, navigation, search, fullscreen toggle with dynamic label)
- `components/PageNavigator.tsx` — 1 button (confirm page number)
- `components/SurahAyaNavigator.tsx` — 2 buttons (close surah/aya modals)
- `app/tracker.tsx` — 1 button (close confirmation modal)
- `app/search.tsx` — 1 button (advanced search options with `accessibilityState`)
- `app/(tabs)/(more)/index.tsx` — 1 button (close error modal)
- `app/(tabs)/(more)/settings.tsx` — 1 button (close reset confirmation modal)

## Test plan
- [ ] Verify all icon-only buttons are announced by screen readers (TalkBack/VoiceOver)
- [ ] Verify fullscreen toggle label updates dynamically based on state
- [ ] Verify search options button announces expanded/collapsed state

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)