### PR TITLE
feat: add scheduled Wird reminder notifications

### DIFF
--- a/app/tracker.tsx
+++ b/app/tracker.tsx
@@ -2,6 +2,8 @@
 import React, { useState } from 'react';
 import {
   Modal,
+  Platform,
+  Pressable,
   ScrollView,
   StyleSheet,
   Text,
@@ -11,6 +13,7 @@ import {
 import { Feather } from '@expo/vector-icons';
 import { Stack } from 'expo-router';
 import { useAtom } from 'jotai/react';
+import Toggle from 'react-native-toggle-input';
 
 import SEO from '@/components/seo';
 import { ThemedButton } from '@/components/ThemedButton';
@@ -19,6 +22,7 @@ import { ThemedView } from '@/components/ThemedView';
 import { useColors } from '@/hooks/useColors';
 import useCurrentPage from '@/hooks/useCurrentPage';
 import { useUpdateAndroidWidget } from '@/hooks/useUpdateAndroidWidget';
+import useWirdNotification from '@/hooks/useWirdNotification';
 import {
   dailyTrackerCompleted,
   dailyTrackerGoal,
@@ -37,6 +41,7 @@ export default function TrackerScreen() {
     dailyTrackerCompleted,
   );
   const [yesterdayPageValue, setYesterdayPageValue] = useAtom(yesterdayPage);
+  const { enabled: reminderEnabled, setEnabled: setReminderEnabled, time: reminderTime, setTime: setReminderTime } = useWirdNotification();
   // Add state for modal visibility
   const [confirmModalVisible, setConfirmModalVisible] = useState(false);
 
@@ -164,6 +169,110 @@ export default function TrackerScreen() {
               </ThemedView>
             </ThemedView>
           </ThemedView>
+
+          {Platform.OS !== 'web' && (
+            <ThemedView
+              style={[styles.navigationSection, { backgroundColor: cardColor }]}
+            >
+              <ThemedView
+                style={[styles.labelContainer, { backgroundColor: cardColor }]}
+              >
+                <Feather
+                  name="clock"
+                  size={24}
+                  color={iconColor}
+                  style={[styles.icon, { color: primaryColor }]}
+                />
+                <ThemedText style={styles.label}>تذكير الورد اليومي:</ThemedText>
+              </ThemedView>
+
+              <Pressable
+                style={styles.reminderToggleRow}
+                onPress={() => setReminderEnabled(!reminderEnabled)}
+                accessibilityRole="button"
+                accessibilityLabel="تفعيل تذكير الورد اليومي"
+                accessibilityState={{ selected: reminderEnabled }}
+              >
+                <ThemedText style={styles.infoText}>تفعيل التذكير:</ThemedText>
+                <Toggle
+                  color={primaryColor}
+                  size={40}
+                  circleColor={primaryColor}
+                  toggle={reminderEnabled}
+                  setToggle={() => setReminderEnabled(!reminderEnabled)}
+                />
+              </Pressable>
+
+              {reminderEnabled && (
+                <ThemedView style={styles.timePickerContainer}>
+                  <ThemedText style={styles.infoText}>وقت التذكير:</ThemedText>
+                  <ThemedView style={styles.timePicker}>
+                    <ThemedView style={styles.timeUnit}>
+                      <TouchableOpacity
+                        style={styles.controlButton}
+                        onPress={() =>
+                          setReminderTime((prev) => ({
+                            ...prev,
+                            hour: (prev.hour + 1) % 24,
+                          }))
+                        }
+                        accessibilityLabel="زيادة الساعة"
+                      >
+                        <Feather name="chevron-up" size={20} color={primaryColor} />
+                      </TouchableOpacity>
+                      <ThemedText style={styles.timeValue}>
+                        {String(reminderTime.hour).padStart(2, '0')}
+                      </ThemedText>
+                      <TouchableOpacity
+                        style={styles.controlButton}
+                        onPress={() =>
+                          setReminderTime((prev) => ({
+                            ...prev,
+                            hour: (prev.hour - 1 + 24) % 24,
+                          }))
+                        }
+                        accessibilityLabel="إنقاص الساعة"
+                      >
+                        <Feather name="chevron-down" size={20} color={primaryColor} />
+                      </TouchableOpacity>
+                    </ThemedView>
+
+                    <ThemedText style={styles.timeSeparator}>:</ThemedText>
+
+                    <ThemedView style={styles.timeUnit}>
+                      <TouchableOpacity
+                        style={styles.controlButton}
+                        onPress={() =>
+                          setReminderTime((prev) => ({
+                            ...prev,
+                            minute: (prev.minute + 5) % 60,
+                          }))
+                        }
+                        accessibilityLabel="زيادة الدقائق"
+                      >
+                        <Feather name="chevron-up" size={20} color={primaryColor} />
+                      </TouchableOpacity>
+                      <ThemedText style={styles.timeValue}>
+                        {String(reminderTime.minute).padStart(2, '0')}
+                      </ThemedText>
+                      <TouchableOpacity
+                        style={styles.controlButton}
+                        onPress={() =>
+                          setReminderTime((prev) => ({
+                            ...prev,
+                            minute: (prev.minute - 5 + 60) % 60,
+                          }))
+                        }
+                        accessibilityLabel="إنقاص الدقائق"
+                      >
+                        <Feather name="chevron-down" size={20} color={primaryColor} />
+                      </TouchableOpacity>
+                    </ThemedView>
+                  </ThemedView>
+                </ThemedView>
+              )}
+            </ThemedView>
+          )}
 
           <ThemedView
             style={[styles.navigationSection, { backgroundColor: cardColor }]}
@@ -358,9 +467,42 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     backgroundColor: 'transparent',
   },
-  resetButton: { paddingHorizontal: 16, paddingVertical: 8 }, // This padding controls the space around the icon and text
+  resetButton: { paddingHorizontal: 16, paddingVertical: 8 },
+  reminderToggleRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    width: '100%',
+    marginBottom: 8,
+  },
+  timePickerContainer: {
+    alignItems: 'center',
+    marginTop: 8,
+  },
+  timePicker: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginTop: 8,
+    backgroundColor: 'transparent',
+  },
+  timeUnit: {
+    alignItems: 'center',
+    backgroundColor: 'transparent',
+  },
+  timeValue: {
+    fontSize: 28,
+    fontFamily: 'Tajawal_700Bold',
+    minWidth: 50,
+    textAlign: 'center',
+  },
+  timeSeparator: {
+    fontSize: 28,
+    fontFamily: 'Tajawal_700Bold',
+    marginHorizontal: 8,
+  },
 
-  // Add Modal Styles (copied from settings.tsx and adjusted slightly)
+  // Modal Styles (copied from settings.tsx and adjusted slightly)
   modalOverlay: {
     flex: 1,
     backgroundColor: 'rgba(0, 0, 0, 0.5)',

--- a/hooks/useWirdNotification.ts
+++ b/hooks/useWirdNotification.ts
@@ -1,0 +1,73 @@
+import { useCallback, useEffect } from 'react';
+import { Platform } from 'react-native';
+
+import * as Notifications from 'expo-notifications';
+import { useAtom } from 'jotai/react';
+
+import { wirdReminderEnabled, wirdReminderTime } from '@/jotai/atoms';
+
+const NOTIFICATION_ID = 'wird-daily-reminder';
+
+Notifications.setNotificationHandler({
+  handleNotification: async () => ({
+    shouldShowAlert: true,
+    shouldPlaySound: true,
+    shouldSetBadge: false,
+  }),
+});
+
+async function requestPermissions(): Promise<boolean> {
+  if (Platform.OS === 'web') return false;
+
+  const { status: existing } = await Notifications.getPermissionsAsync();
+  if (existing === 'granted') return true;
+
+  const { status } = await Notifications.requestPermissionsAsync();
+  return status === 'granted';
+}
+
+export default function useWirdNotification() {
+  const [enabled, setEnabled] = useAtom(wirdReminderEnabled);
+  const [time, setTime] = useAtom(wirdReminderTime);
+
+  const scheduleNotification = useCallback(async () => {
+    if (Platform.OS === 'web') return;
+
+    await Notifications.cancelScheduledNotificationAsync(NOTIFICATION_ID);
+
+    const hasPermission = await requestPermissions();
+    if (!hasPermission) {
+      setEnabled(false);
+      return;
+    }
+
+    await Notifications.scheduleNotificationAsync({
+      identifier: NOTIFICATION_ID,
+      content: {
+        title: 'تذكير الورد اليومي',
+        body: 'حان وقت قراءة وردك اليومي من القرآن الكريم',
+        sound: true,
+      },
+      trigger: {
+        type: Notifications.SchedulableTriggerInputTypes.DAILY,
+        hour: time.hour,
+        minute: time.minute,
+      },
+    });
+  }, [time.hour, time.minute, setEnabled]);
+
+  const cancelNotification = useCallback(async () => {
+    if (Platform.OS === 'web') return;
+    await Notifications.cancelScheduledNotificationAsync(NOTIFICATION_ID);
+  }, []);
+
+  useEffect(() => {
+    if (enabled) {
+      scheduleNotification();
+    } else {
+      cancelNotification();
+    }
+  }, [enabled, scheduleNotification, cancelNotification]);
+
+  return { enabled, setEnabled, time, setTime };
+}

--- a/jotai/atoms.ts
+++ b/jotai/atoms.ts
@@ -128,3 +128,19 @@ export const readingBannerCollapsedState = createAtomWithStorage<boolean>(
   'ReadingBannerCollapsedState',
   false,
 );
+
+// Wird reminder notification
+type WirdReminderTime = {
+  hour: number;
+  minute: number;
+};
+
+export const wirdReminderEnabled = createAtomWithStorage<boolean>(
+  'WirdReminderEnabled',
+  false,
+);
+
+export const wirdReminderTime = createAtomWithStorage<WirdReminderTime>(
+  'WirdReminderTime',
+  { hour: 7, minute: 0 },
+);

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "expo-audio": "~1.1.1",
     "expo-build-properties": "~1.0.10",
     "expo-constants": "~18.0.12",
+    "expo-notifications": "~0.34.0",
     "expo-font": "~14.0.10",
     "expo-image": "~3.0.11",
     "expo-keep-awake": "~15.0.8",


### PR DESCRIPTION
## Summary
- Add `expo-notifications` for scheduling daily local reminders
- New `useWirdNotification` hook handles permission requests, scheduling, and cancellation
- New atoms `wirdReminderEnabled` and `wirdReminderTime` persist user preferences
- Time picker UI in tracker screen with hour/minute controls (5-min increments)
- Hidden on web (native-only feature)

## Implementation details
- Notification scheduled as a daily repeating trigger at user-selected time
- Arabic notification: "تذكير الورد اليومي" / "حان وقت قراءة وردك اليومي من القرآن الكريم"
- Default reminder time: 07:00
- Permission denied gracefully disables the toggle

## Test plan
- [ ] Enable reminder toggle and verify notification permission prompt appears
- [ ] Set a reminder time and verify notification fires at scheduled time
- [ ] Disable reminder and verify notification is cancelled
- [ ] Verify reminder section is hidden on web
- [ ] Verify time persists across app restarts

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)