### PR TITLE
feat: add custom reading themes (Sepia, High Contrast)

### DIFF
--- a/app/(tabs)/(more)/settings.tsx
+++ b/app/(tabs)/(more)/settings.tsx
@@ -13,13 +13,14 @@ import SEO from '@/components/seo';
 import { ThemedButton } from '@/components/ThemedButton';
 import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
-import { riwayaOptions } from '@/constants';
+import { riwayaOptions, READING_THEME_KEYS, READING_THEME_LABELS } from '@/constants';
 import { useColors } from '@/hooks/useColors';
 import {
   flipSound,
   hizbNotification,
   mushafContrast,
   mushafRiwaya,
+  readingTheme,
   showTrackerNotification,
 } from '@/jotai/atoms';
 import { RiwayaByIndice, RiwayaByValue } from '@/utils';
@@ -35,6 +36,7 @@ export default function SettingsScreen() {
   const { textColor, primaryColor, cardColor, iconColor } = useColors();
   const [mushafContrastValue, setMushafContrastValue] = useAtom(mushafContrast);
   const [mushafRiwayaValue, setMushafRiwayaValue] = useAtom(mushafRiwaya);
+  const [readingThemeValue, setReadingThemeValue] = useAtom(readingTheme);
   const [confirmModalVisible, setConfirmModalVisible] = useState(false);
 
   const toggleFlipSoundSwitch = () => {
@@ -212,6 +214,46 @@ export default function SettingsScreen() {
             onSelectionChange={(index: number) =>
               handleHizbNotificationValueChange(index)
             }
+          />
+        </Pressable>
+      </ThemedView>
+
+      <ThemedView
+        style={[
+          styles.settingsSection,
+          styles.columnSection,
+          { backgroundColor: cardColor },
+        ]}
+      >
+        <ThemedView
+          style={[
+            styles.fullWidthContainer,
+            styles.iconTextContainer,
+            { backgroundColor: cardColor },
+          ]}
+        >
+          <Feather
+            name="eye"
+            size={24}
+            color={iconColor}
+            style={styles.iconStyle}
+          />
+          <ThemedText
+            type="defaultSemiBold"
+            style={[styles.itemText, styles.fullWidth]}
+          >
+            سمة القراءة:
+          </ThemedText>
+        </ThemedView>
+        <Pressable style={styles.fullWidth} accessibilityRole="radiogroup">
+          <SegmentedControl
+            options={READING_THEME_LABELS}
+            initialSelectedIndex={READING_THEME_KEYS.indexOf(readingThemeValue)}
+            activeColor={primaryColor}
+            textColor={primaryColor}
+            onSelectionChange={(index: number) => {
+              setReadingThemeValue(READING_THEME_KEYS[index]);
+            }}
           />
         </Pressable>
       </ThemedView>

--- a/components/MushafPage.tsx
+++ b/components/MushafPage.tsx
@@ -26,12 +26,14 @@ import useImagesArray from '@/hooks/useImagesArray';
 import useOrientation from '@/hooks/useOrientation';
 import { usePanGestureHandler } from '@/hooks/usePanGestureHandler';
 import useQuranMetadata from '@/hooks/useQuranMetadata';
+import { READING_THEME_KEYS, READING_THEMES } from '@/constants/readingThemes';
 import {
   dailyTrackerCompleted,
   dailyTrackerGoal,
   flipSound,
   hizbNotification,
   mushafContrast,
+  readingTheme,
   showTrackerNotification,
   yesterdayPage,
 } from '@/jotai/atoms';
@@ -50,6 +52,8 @@ export default function MushafPage() {
   const player = useAudioPlayer(audioSource);
   const isFlipSoundEnabled = useAtomValue(flipSound);
   const mushafContrastValue = useAtomValue(mushafContrast);
+  const readingThemeValue = useAtomValue(readingTheme);
+  const themeConfig = READING_THEMES[readingThemeValue] || READING_THEMES.default;
 
   const hizbNotificationValue = useAtomValue(hizbNotification);
   const [showHizbNotification, setShowHizbNotification] = useState(false);
@@ -340,7 +344,7 @@ export default function MushafPage() {
               backgroundColor:
                 colorScheme === 'dark'
                   ? `rgba(26, 26, 26, ${1 - mushafContrastValue})`
-                  : ivoryColor,
+                  : themeConfig.backgroundColor || ivoryColor,
             },
           ]}
           onLayout={handleImageLayout}
@@ -360,6 +364,10 @@ export default function MushafPage() {
                       colorScheme === 'dark' && {
                         opacity: mushafContrastValue,
                       },
+                      colorScheme !== 'dark' &&
+                        themeConfig.imageOpacity < 1 && {
+                          opacity: themeConfig.imageOpacity,
+                        },
                     ]}
                     source={{ uri: asset?.localUri }}
                     contentFit="fill"
@@ -373,6 +381,10 @@ export default function MushafPage() {
                     colorScheme === 'dark' && {
                       opacity: mushafContrastValue,
                     },
+                    colorScheme !== 'dark' &&
+                      themeConfig.imageOpacity < 1 && {
+                        opacity: themeConfig.imageOpacity,
+                      },
                   ]}
                   source={{ uri: asset?.localUri }}
                   contentFit="fill"

--- a/constants/index.ts
+++ b/constants/index.ts
@@ -9,3 +9,5 @@ export * from './slides';
 export * from './readingPositionBannerHeights';
 
 export * from './riwayaOptions';
+
+export * from './readingThemes';

--- a/constants/readingThemes.ts
+++ b/constants/readingThemes.ts
@@ -1,0 +1,25 @@
+export type ReadingThemeConfig = {
+  backgroundColor: string;
+  imageOpacity: number;
+  tintColor?: string;
+};
+
+export const READING_THEMES: Record<string, ReadingThemeConfig> = {
+  default: {
+    backgroundColor: '',
+    imageOpacity: 1,
+  },
+  sepia: {
+    backgroundColor: '#F4E8D1',
+    imageOpacity: 0.92,
+    tintColor: 'sepia',
+  },
+  highContrast: {
+    backgroundColor: '#FFFFFF',
+    imageOpacity: 1,
+  },
+};
+
+export const READING_THEME_LABELS = ['عادي', 'ورقي', 'تباين عالي'];
+
+export const READING_THEME_KEYS = ['default', 'sepia', 'highContrast'];

--- a/jotai/atoms.ts
+++ b/jotai/atoms.ts
@@ -123,6 +123,12 @@ observe((get, set) => {
   }
 });
 
+// Reading theme: 'default' | 'sepia' | 'highContrast'
+export const readingTheme = createAtomWithStorage<string>(
+  'ReadingTheme',
+  'default',
+);
+
 // ReadingPositionBanner
 export const readingBannerCollapsedState = createAtomWithStorage<boolean>(
   'ReadingBannerCollapsedState',


### PR DESCRIPTION
## Summary
- Add three reading themes: Default (عادي), Sepia (ورقي), High Contrast (تباين عالي)
- New `readingTheme` atom persists user's theme choice
- Theme constants defined in `constants/readingThemes.ts`
- MushafPage applies theme background color and image opacity
- Segmented control selector added to settings screen

## Implementation
- **Default**: Standard ivory background (existing behavior)
- **Sepia**: Warm paper-like background (#F4E8D1) with slightly reduced image opacity (0.92)
- **High Contrast**: Pure white background (#FFFFFF) with full image opacity
- Dark mode contrast slider continues to work independently

## Test plan
- [ ] Switch between all three themes and verify MushafPage background changes
- [ ] Verify theme persists across app restarts
- [ ] Verify dark mode contrast slider still works when default theme selected
- [ ] Verify segmented control shows correct initial selection

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)