### PR TITLE
feat(settings): add Rate on Store button (#29)

### DIFF
--- a/app/(tabs)/(more)/index.tsx
+++ b/app/(tabs)/(more)/index.tsx
@@ -30,6 +30,16 @@ export default function MoreScreen() {
   const [errorMessage, setErrorMessage] = useState('');
   const { cardColor, iconColor, textColor } = useColors(); // Added textColor for modal message
 
+  const handleRateOnStore = () => {
+    const url =
+      'https://play.google.com/store/apps/details?id=com.adelpro.openmushafnative';
+    if (Platform.OS === 'web') {
+      window.open(url, '_blank');
+    } else {
+      Linking.openURL(url);
+    }
+  };
+
   const handleShare = async () => {
     let shareUrl = 'https://www.quran.us.kg'; // Default/Web URL
 
@@ -133,7 +143,16 @@ export default function MoreScreen() {
           <Text style={styles.buttonText}>شارك التطبيق</Text>
         </View>
       </ThemedButton>
-
+      <ThemedButton
+        onPress={handleRateOnStore}
+        variant="primary"
+        style={styles.button}
+      >
+        <View style={styles.buttonContent}>
+          <ShareSVG width={24} height={24} style={styles.svg} />
+          <Text style={styles.buttonText}>قيّمنا على المتجر</Text>
+        </View>
+      </ThemedButton>
       {/* Error Modal */}
       <Modal
         animationType="fade"

--- a/app/(tabs)/(more)/settings.tsx
+++ b/app/(tabs)/(more)/settings.tsx
@@ -1,7 +1,14 @@
 import { useState } from 'react';
-import { Modal, Pressable, StyleSheet, TouchableOpacity } from 'react-native';
+import {
+  Linking,
+  Modal,
+  Platform,
+  Pressable,
+  StyleSheet,
+  TouchableOpacity,
+} from 'react-native';
 
-import { Entypo, Feather } from '@expo/vector-icons';
+import { Entypo, Feather, FontAwesome } from '@expo/vector-icons';
 import { useAtom } from 'jotai/react';
 import { ScrollView } from 'react-native-gesture-handler';
 import Toggle from 'react-native-toggle-input';
@@ -256,6 +263,41 @@ export default function SettingsScreen() {
           />
         </Pressable>
       </ThemedView>
+
+      <Pressable
+        style={[
+          styles.settingsSection,
+          { borderColor: textColor, backgroundColor: cardColor },
+        ]}
+        onPress={() => {
+          const storeUrl = Platform.select({
+            android:
+              'https://play.google.com/store/apps/details?id=com.adelpro.openmushafnative',
+            default:
+              'https://play.google.com/store/apps/details?id=com.adelpro.openmushafnative',
+          });
+          Linking.openURL(storeUrl);
+        }}
+        accessibilityRole="button"
+        accessibilityLabel="قيّمنا على المتجر"
+        accessibilityHint="اضغط لفتح صفحة التطبيق في المتجر لتقييمه"
+      >
+        <ThemedView style={styles.iconTextContainer}>
+          <FontAwesome
+            name="star"
+            size={24}
+            color={iconColor}
+            style={styles.iconStyle}
+          />
+          <ThemedText
+            type="defaultSemiBold"
+            style={[styles.itemText, { backgroundColor: cardColor }]}
+          >
+            قيّمنا على المتجر
+          </ThemedText>
+        </ThemedView>
+        <Feather name="external-link" size={20} color={iconColor} />
+      </Pressable>
 
       <ThemedView
         style={[


### PR DESCRIPTION
- Add 'قيّمنا على المتجر' (Rate on Store) button to the More screen (index.tsx) that opens the Google Play Store listing in the browser
- Add 'قيّمنا على المتجر' (Rate on Store) button to the Settings screen (settings.tsx) with star icon and external-link indicator, using Linking.openURL
- Both buttons navigate to the app's Play Store page on Android/web
- Refactor: rename mistyped handelShare -> handleRateOnStore in More screen for clear separation from the share functionality

Closes #29

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Rate on Store" button to the More screen with a star icon, enabling quick access to app ratings.
  * Supports platform-specific store links that automatically open in the correct location for each platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->