### PR TITLE
feat: Add Rate on Store feature (Issue #29)

### DIFF
--- a/app/(tabs)/(more)/settings.tsx
+++ b/app/(tabs)/(more)/settings.tsx
@@ -1,7 +1,7 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Modal, Pressable, StyleSheet, TouchableOpacity } from 'react-native';
 
-import { Entypo, Feather } from '@expo/vector-icons';
+import { Entypo, Feather, FontAwesome } from '@expo/vector-icons';
 import { useAtom } from 'jotai/react';
 import { ScrollView } from 'react-native-gesture-handler';
 import Toggle from 'react-native-toggle-input';
@@ -15,6 +15,7 @@ import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
 import { riwayaOptions } from '@/constants';
 import { useColors } from '@/hooks/useColors';
+import { useRateApp } from '@/hooks/useRateApp';
 import {
   flipSound,
   hizbNotification,
@@ -36,6 +37,7 @@ export default function SettingsScreen() {
   const [mushafContrastValue, setMushafContrastValue] = useAtom(mushafContrast);
   const [mushafRiwayaValue, setMushafRiwayaValue] = useAtom(mushafRiwaya);
   const [confirmModalVisible, setConfirmModalVisible] = useState(false);
+  const { rateAppManually, launchCount, hasRated } = useRateApp();
 
   const toggleFlipSoundSwitch = () => {
     setIsFlipSoundEnabled((previousState) => !previousState);
@@ -254,6 +256,36 @@ export default function SettingsScreen() {
               setMushafRiwayaValue(selectedRiwaya);
             }}
           />
+        </Pressable>
+      </ThemedView>
+
+      {/* Rate App Section */}
+      <ThemedView
+        style={[
+          styles.settingsSection,
+          styles.columnSection,
+          { backgroundColor: cardColor },
+        ]}
+      >
+        <Pressable
+          style={styles.iconTextContainer}
+          accessibilityRole="button"
+          accessibilityLabel="قيّم التطبيق على المتجر"
+          accessibilityHint="افتح المتجر لتقييم التطبيق"
+          onPress={rateAppManually}
+        >
+          <FontAwesome
+            name="star"
+            size={24}
+            color={iconColor}
+            style={styles.iconStyle}
+          />
+          <ThemedText
+            type="defaultSemiBold"
+            style={[styles.itemText, { backgroundColor: cardColor }]}
+          >
+            قيّم التطبيق {hasRated ? '(تم التقييم)' : `(${launchCount} استخدامات)`}
+          </ThemedText>
         </Pressable>
       </ThemedView>
 

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -31,6 +31,7 @@ import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context';
 
 import Notification from '@/components/Notification';
 import SEO from '@/components/seo';
+import { useRateApp } from '@/hooks/useRateApp';
 import { isRTL } from '@/utils';
 
 import { NotificationProvider } from '../components/NotificationProvider';
@@ -43,6 +44,7 @@ SplashScreen.setOptions({ fade: true, duration: 1000 });
 
 export default function RootLayout() {
   const colorScheme = useColorScheme();
+  const { isReadyToShowPrompt, showRatePrompt } = useRateApp();
 
   const [fontLoaded, fontError] = useFonts({
     Amiri_400Regular,
@@ -81,6 +83,18 @@ export default function RootLayout() {
       SplashScreen.hideAsync();
     }
   }, [fontError, fontLoaded]);
+
+  // Show rate prompt after app has been used 5+ times
+  useEffect(() => {
+    if (fontLoaded && isReadyToShowPrompt) {
+      // Delay the prompt to avoid showing it immediately on app launch
+      const timer = setTimeout(() => {
+        showRatePrompt();
+      }, 5000); // Show after 5 seconds
+
+      return () => clearTimeout(timer);
+    }
+  }, [fontLoaded, isReadyToShowPrompt, showRatePrompt]);
 
   if (!fontLoaded && !fontError) {
     return null;

--- a/hooks/useRateApp.ts
+++ b/hooks/useRateApp.ts
@@ -1,0 +1,117 @@
+import { useCallback, useEffect } from 'react';
+import { Alert, Platform } from 'react-native';
+
+import * as Linking from 'expo-linking';
+import * as StoreReview from 'expo-store-review';
+import { useAtom } from 'jotai/react';
+
+import {
+  appLaunchCount,
+  hasUserRatedApp,
+  ratePromptLastShown,
+} from '@/jotai/atoms';
+
+const MIN_LAUNCH_COUNT = 5;
+const PROMPT_COOLDOWN_DAYS = 30;
+const STORE_URLS = {
+  android:
+    'https://play.google.com/store/apps/details?id=com.adelpro.openmushafnative',
+  ios: '', // Add iOS App Store URL when available
+};
+
+export function useRateApp() {
+  const [launchCount, setLaunchCount] = useAtom(appLaunchCount);
+  const [hasRated, setHasRated] = useAtom(hasUserRatedApp);
+  const [lastShown, setLastShown] = useAtom(ratePromptLastShown);
+
+  // Increment launch count on app start
+  useEffect(() => {
+    setLaunchCount((prev) => prev + 1);
+  }, [setLaunchCount]);
+
+  const isReadyToShowPrompt = useCallback(() => {
+    if (hasRated) return false;
+    if (launchCount < MIN_LAUNCH_COUNT) return false;
+
+    const now = Date.now();
+    const cooldownMs = PROMPT_COOLDOWN_DAYS * 24 * 60 * 60 * 1000;
+    if (lastShown > 0 && now - lastShown < cooldownMs) return false;
+
+    return true;
+  }, [hasRated, launchCount, lastShown]);
+
+  const openStoreForRating = useCallback(async () => {
+    try {
+      // Try native in-app review first
+      const isAvailable = await StoreReview.isAvailableAsync();
+      if (isAvailable) {
+        await StoreReview.requestReview();
+        setHasRated(true);
+        return true;
+      }
+
+      // Fallback to store URL
+      const storeUrl =
+        Platform.OS === 'ios' ? STORE_URLS.ios : STORE_URLS.android;
+
+      if (storeUrl) {
+        const canOpen = await Linking.canOpenURL(storeUrl);
+        if (canOpen) {
+          await Linking.openURL(storeUrl);
+          setHasRated(true);
+          return true;
+        }
+      }
+
+      return false;
+    } catch (error) {
+      console.error('Error opening store for rating:', error);
+      return false;
+    }
+  }, [setHasRated]);
+
+  const showRatePrompt = useCallback(() => {
+    if (!isReadyToShowPrompt()) return;
+
+    setLastShown(Date.now());
+
+    Alert.alert(
+      'قيّم التطبيق',
+      'هل تستمتع باستخدام المصحف المفتوح؟ نقدر تقييمك لنا على المتجر!',
+      [
+        {
+          text: 'لاحقاً',
+          style: 'cancel',
+        },
+        {
+          text: 'قيّم الآن',
+          onPress: openStoreForRating,
+        },
+        {
+          text: 'لا، شكراً',
+          onPress: () => setHasRated(true),
+          style: 'destructive',
+        },
+      ],
+      { cancelable: true }
+    );
+  }, [isReadyToShowPrompt, openStoreForRating, setHasRated, setLastShown]);
+
+  const rateAppManually = useCallback(async () => {
+    const success = await openStoreForRating();
+    if (!success) {
+      Alert.alert(
+        'عذراً',
+        'تعذر فتح المتجر. يرجى المحاولة مرة أخرى لاحقاً.'
+      );
+    }
+  }, [openStoreForRating]);
+
+  return {
+    launchCount,
+    hasRated,
+    isReadyToShowPrompt: isReadyToShowPrompt(),
+    showRatePrompt,
+    rateAppManually,
+  };
+}

--- a/jotai/atoms.ts
+++ b/jotai/atoms.ts
@@ -51,6 +51,11 @@ export const showTrackerNotification = createAtomWithStorage<boolean>(
   false,
 );
 
+// Rate on Store feature
+export const appLaunchCount = createAtomWithStorage<number>('AppLaunchCount', 0);
+export const hasUserRatedApp = createAtomWithStorage<boolean>('HasUserRatedApp', false);
+export const ratePromptLastShown = createAtomWithStorage<number>('RatePromptLastShown', 0);
+
 // Type declarations
 type DailyTrackerProgress = {
   value: number;

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "expo-secure-store": "~15.0.8",
     "expo-splash-screen": "~31.0.13",
     "expo-status-bar": "~3.0.9",
+    "expo-store-review": "~8.0.1",
     "expo-system-ui": "~6.0.9",
     "expo-updates": "~29.0.15",
     "expo-web-browser": "~15.0.10",


### PR DESCRIPTION
## Description

This PR implements the Rate on Store feature as requested in Issue #29 (100 pts).

## Changes

### New Features
- **Rate on Store Button**: Added a new option in Settings menu allowing users to manually rate the app
- **Auto-prompt**: Users are automatically prompted to rate the app after 5+ launches
- **Smart Cooldown**: 30-day cooldown period between rating prompts to avoid annoying users
- **Native In-App Review**: Uses `expo-store-review` for native rating experience when available
- **Fallback to Store URL**: Falls back to Play Store/App Store URL if native review isn't available

### Technical Implementation
- Added `expo-store-review` dependency
- Created `useRateApp` hook for centralized rating logic
- Added Jotai atoms for persistent storage:
  - `appLaunchCount`: Tracks number of app launches
  - `hasUserRatedApp`: Prevents showing prompt to users who already rated
  - `ratePromptLastShown`: Tracks last prompt timestamp for cooldown
- Integrated rating prompt in root layout (shows 5 seconds after app launch)
- Added rating button to Settings screen with usage counter display

### User Experience
- Prompt only appears after 5 app launches
- Users can dismiss with "Later" or permanently with "No thanks"
- Settings menu shows current usage count and rating status
- Arabic localization for all UI text

## Testing
- Verified launch count increment on app start
- Tested manual rating button functionality
- Confirmed auto-prompt appears after 5 launches
- Validated cooldown period functionality

Closes #29

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added in-app rating prompts that appear after specific usage milestones.
  * New "Rate App" section available in Settings screen.
  * Users can rate the app, dismiss the prompt, or set reminders later.
  * Built-in fallback to app store if in-app rating isn't available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->