### PR TITLE
fix(iOS): replace raw route names in back button labels

### DIFF
--- a/app/(tabs)/(more)/_layout.tsx
+++ b/app/(tabs)/(more)/_layout.tsx
@@ -12,6 +12,10 @@ export default function MoreLayout() {
       }}
     >
       <Stack.Screen
+        name="index"
+        options={{ headerShown: false, title: 'المزيد' }}
+      />
+      <Stack.Screen
         name="privacy"
         options={{ headerShown: true, title: 'الخصوصية' }}
       />

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -114,7 +114,7 @@ export default function RootLayout() {
                 >
                   <Stack.Screen
                     name="(tabs)"
-                    options={{ headerShown: false }}
+                    options={{ headerShown: false, title: 'الرئيسية' }}
                   />
                   <Stack.Screen name="+not-found" />
                   <Stack.Screen


### PR DESCRIPTION
Context
Issue #77: on iOS, back buttons in nested stacks were showing raw route names like `index` and `(tabs)`.

Fix
- Set explicit hidden parent title for root `(tabs)` stack route in `app/_layout.tsx`.
- Set explicit hidden `index` title for `(more)` stack in `app/(tabs)/(more)/_layout.tsx`.
- This ensures iOS back button labels resolve to meaningful text instead of route keys.

How to test
1. Run the app on iOS simulator/device.
2. Go to More tab, then open Settings/Privacy/Contact/About.
3. Verify back label is no longer `index`.
4. Open Tutorial (and other root stack screens reached from tabs context).
5. Verify back label is no longer `(tabs)`.
6. Optional sanity checks:
   - `npx eslint app/_layout.tsx 'app/(tabs)/(more)/_layout.tsx'` (passes)
   - `npx jest --watchAll=false` (currently fails in existing suite due to react-test-renderer env mismatch)

Screenshots / Evidence
- Lint passes for modified files.
- Manual iOS navigation verification required.

Risk / Rollback plan
- Low risk: change is limited to stack screen options (titles) and does not alter navigation paths.
- Rollback by reverting commit `8e8f562`.

Checklist
- [x] Lint passes
- [ ] Tests pass
- [ ] Build passes
- [ ] Safari tested (if relevant)

closes #77


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated navigation configuration to enhance screen organization and layout structure.
  * Added localized screen titles for improved navigation experience throughout the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->