### PR TITLE
fix(iOS): remove root safe-area dead space causing black bars

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -4,6 +4,7 @@ import {
   InteractionManager,
   Platform,
   useColorScheme,
+  View,
 } from 'react-native';
 
 import {
@@ -27,7 +28,7 @@ import { StatusBar } from 'expo-status-bar';
 import * as Updates from 'expo-updates';
 import { HelmetProvider } from 'react-helmet-async';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
-import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
 
 import ErrorBoundary from '@/components/ErrorBoundary';
 import Notification from '@/components/Notification';
@@ -108,7 +109,7 @@ export default function RootLayout() {
           <SEO />
           <GestureHandlerRootView style={{ flex: 1 }}>
             <SafeAreaProvider>
-              <SafeAreaView
+              <View
                 style={{
                   flex: 1,
                   width: '100%',
@@ -159,7 +160,7 @@ export default function RootLayout() {
                   </Stack>
                   <Notification />
                 </ThemeProvider>
-              </SafeAreaView>
+              </View>
             </SafeAreaProvider>
           </GestureHandlerRootView>
         </HelmetProvider>


### PR DESCRIPTION
Context

Fixes iOS black bars caused by the root `SafeAreaView` in `app/_layout.tsx` adding dead space with a transparent background.

Closes #76.

Fix

- Replaced root `SafeAreaView` with a plain `View` in `app/_layout.tsx`.
- Kept `SafeAreaProvider` in place for downstream safe-area consumers.
- Updated imports accordingly.

How to test

1. Run the app on iOS (`npm run ios` / Expo iOS).
2. Open the main reader screen.
3. Verify content renders edge-to-edge without large black bars above or below.

Screenshots / Evidence

- Code diff in `app/_layout.tsx`.

Risk / Rollback plan

- Risk is low; change is limited to root wrapper component.
- Rollback by restoring root `SafeAreaView` in `app/_layout.tsx` if any screen relies on root-level inset padding.

Checklist
- [ ] Lint passes
- [ ] Tests pass
- [ ] Build passes
- [ ] Safari tested (if relevant)
