### PR TITLE
fix(lists): use iOS safe area inset instead of hardcoded top margin

### DIFF
--- a/app/(tabs)/lists.tsx
+++ b/app/(tabs)/lists.tsx
@@ -1,5 +1,7 @@
 import { useState } from 'react';
-import { ScrollView } from 'react-native';
+import { Platform, ScrollView, StyleSheet } from 'react-native';
+
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import ChapterList from '@/components/ChapterList';
 import SEO from '@/components/seo';
@@ -10,8 +12,15 @@ import { ListTabs } from '@/types';
 
 export default function ListsScreen() {
   const [activeTab, setActiveTab] = useState<ListTabs>('surahs');
+  const insets = useSafeAreaInsets();
+
   return (
-    <ThemedView style={{ flex: 1, marginTop: 30 }}>
+    <ThemedView
+      style={[
+        styles.container,
+        { paddingTop: Platform.OS === 'ios' ? insets.top : 0 },
+      ]}
+    >
       <SEO
         title="القوائم"
         description="قائمة السور والأجزاء - المصحف المفتوح"
@@ -24,3 +33,9 @@ export default function ListsScreen() {
     </ThemedView>
   );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+});


### PR DESCRIPTION
Context
This PR fixes issue #80 on the Lists screen where a hardcoded `marginTop: 30` caused inconsistent spacing across iOS devices with different safe area sizes.

Fix
- Replaced hardcoded top margin in `app/(tabs)/lists.tsx`.
- Added `useSafeAreaInsets()` and applied dynamic top spacing on iOS only.
- Switched to `paddingTop: insets.top` for safe-area-aware layout behavior.

How to test
1. Open Lists screen on iOS devices/simulators with different notch/safe-area sizes.
2. Verify top spacing is consistent and not too high/too low.
3. Confirm Android/web layout remains unchanged.

Screenshots / Evidence
- Layout fix; verify visually on iOS simulators/devices.

Risk / Rollback plan
- Low risk and isolated to Lists container spacing.
- Rollback by reverting commit `170b283`.

Checklist
- [x] Lint passes
- [ ] Tests pass
- [ ] Build passes
- [ ] Safari tested (if relevant)

closes #80
