### PR TITLE
fix: remove duplicated thumn entry in mushaf-elmadina-warsh-azrak

### DIFF
--- a/assets/quran-metadata/mushaf-elmadina-warsh-azrak/thumn.json
+++ b/assets/quran-metadata/mushaf-elmadina-warsh-azrak/thumn.json
@@ -502,7 +502,7 @@
     "sura_number": 4,
     "starting_aya": 79,
     "startingPage": 90
-  },  
+  },
   {
     "hizb_number": 10,
     "thumn": 1,
@@ -614,8 +614,8 @@
     "sura_number": 5,
     "starting_aya": 17,
     "startingPage": 110
-  },  
-    {
+  },
+  {
     "hizb_number": 12,
     "thumn": 1,
     "sura_number": 5,
@@ -1062,7 +1062,8 @@
     "sura_number": 9,
     "starting_aya": 28,
     "startingPage": 191
-  },{
+  },
+  {
     "hizb_number": 20,
     "thumn": 1,
     "sura_number": 9,
@@ -1083,7 +1084,7 @@
     "starting_aya": 46,
     "startingPage": 194
   },
-    {
+  {
     "hizb_number": 20,
     "thumn": 4,
     "sura_number": 9,
@@ -1111,7 +1112,7 @@
     "starting_aya": 75,
     "startingPage": 199
   },
-    {
+  {
     "hizb_number": 20,
     "thumn": 8,
     "sura_number": 9,
@@ -1167,14 +1168,13 @@
     "starting_aya": 11,
     "startingPage": 209
   },
-    {
+  {
     "hizb_number": 21,
     "thumn": 8,
     "sura_number": 10,
     "starting_aya": 19,
     "startingPage": 210
   },
-
   {
     "hizb_number": 22,
     "thumn": 1,
@@ -1224,7 +1224,7 @@
     "starting_aya": 93,
     "startingPage": 219
   },
-    {
+  {
     "hizb_number": 22,
     "thumn": 8,
     "sura_number": 10,
@@ -1392,7 +1392,7 @@
     "starting_aya": 5,
     "startingPage": 249
   },
-    {
+  {
     "hizb_number": 25,
     "thumn": 8,
     "sura_number": 13,
@@ -1699,7 +1699,7 @@
     "sura_number": 18,
     "starting_aya": 102,
     "startingPage": 304
-  },  
+  },
   {
     "hizb_number": 31,
     "thumn": 4,
@@ -1727,7 +1727,8 @@
     "sura_number": 19,
     "starting_aya": 59,
     "startingPage": 309
-  },  {
+  },
+  {
     "hizb_number": 31,
     "thumn": 8,
     "sura_number": 19,
@@ -1748,7 +1749,7 @@
     "starting_aya": 36,
     "startingPage": 313
   },
-    {
+  {
     "hizb_number": 32,
     "thumn": 3,
     "sura_number": 20,
@@ -1957,7 +1958,8 @@
     "sura_number": 24,
     "starting_aya": 11,
     "startingPage": 351
-  },  {
+  },
+  {
     "hizb_number": 36,
     "thumn": 1,
     "sura_number": 24,
@@ -2178,7 +2180,7 @@
     "hizb_number": 39,
     "thumn": 8,
     "sura_number": 28,
-    "starting_aya":39,
+    "starting_aya": 39,
     "startingPage": 390
   },
   {
@@ -2346,7 +2348,7 @@
     "hizb_number": 42,
     "thumn": 8,
     "sura_number": 33,
-    "starting_aya":25,
+    "starting_aya": 25,
     "startingPage": 421
   },
   {
@@ -2367,7 +2369,7 @@
     "hizb_number": 43,
     "thumn": 3,
     "sura_number": 33,
-    "starting_aya":49,
+    "starting_aya": 49,
     "startingPage": 424
   },
   {
@@ -2460,13 +2462,8 @@
     "sura_number": 36,
     "starting_aya": 7,
     "startingPage": 440
-  },  {
-    "hizb_number": 45,
-    "thumn": 1,
-    "sura_number": 36,
-    "starting_aya": 28,
-    "startingPage": 442
-  },  {
+  },
+  {
     "hizb_number": 45,
     "thumn": 1,
     "sura_number": 36,
@@ -2601,7 +2598,7 @@
   },
   {
     "hizb_number": 47,
-    "thumn":4,
+    "thumn": 4,
     "sura_number": 39,
     "starting_aya": 67,
     "startingPage": 465
@@ -2629,7 +2626,7 @@
   },
   {
     "hizb_number": 47,
-    "thumn":8,
+    "thumn": 8,
     "sura_number": 40,
     "starting_aya": 30,
     "startingPage": 470
@@ -2648,14 +2645,14 @@
     "starting_aya": 53,
     "startingPage": 473
   },
-    {
+  {
     "hizb_number": 48,
-    "thumn":3,
+    "thumn": 3,
     "sura_number": 40,
     "starting_aya": 66,
     "startingPage": 474
   },
-    {
+  {
     "hizb_number": 48,
     "thumn": 4,
     "sura_number": 40,
@@ -2764,7 +2761,7 @@
     "hizb_number": 50,
     "thumn": 3,
     "sura_number": 43,
-    "starting_aya":63,
+    "starting_aya": 63,
     "startingPage": 494
   },
   {
@@ -2969,7 +2966,8 @@
     "sura_number": 54,
     "starting_aya": 37,
     "startingPage": 530
-  },  {
+  },
+  {
     "hizb_number": 54,
     "thumn": 1,
     "sura_number": 55,


### PR DESCRIPTION
## What does this PR do?
Removes a duplicated thumn entry in mushaf-elmadina-warsh-azrak/thumn.json

## Related Issue
Fixes #88

## Changes
- Removed duplicate entry: hizb_number 45, thumn 1, sura_number 36, starting_aya 28, startingPage 442

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated data structure with placeholder entries and minor formatting adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->