### PR TITLE
fix(ios): RTL alignment on About and Settings screens

### DIFF
--- a/app/(tabs)/(more)/about.tsx
+++ b/app/(tabs)/(more)/about.tsx
@@ -159,6 +159,7 @@ const styles = StyleSheet.create({
     maxWidth: 600,
     paddingHorizontal: 22,
     alignSelf: 'center',
+    writingDirection: 'rtl',
   },
   title: {
     fontSize: 20,
@@ -167,7 +168,7 @@ const styles = StyleSheet.create({
   },
   listContainer: {
     marginBottom: 5,
-    paddingLeft: 16,
+    paddingStart: 16,
   },
   listItem: {
     marginBottom: 10,
@@ -179,6 +180,7 @@ const styles = StyleSheet.create({
     fontWeight: '500',
   },
   listText: {
+    flex: 1,
     fontSize: 16,
     lineHeight: 22,
   },

--- a/app/(tabs)/(more)/settings.tsx
+++ b/app/(tabs)/(more)/settings.tsx
@@ -386,6 +386,7 @@ const styles = StyleSheet.create({
     alignSelf: 'center',
     width: '100%',
     maxWidth: 640,
+    writingDirection: 'rtl',
   },
   settingsSection: {
     width: '100%',


### PR DESCRIPTION
## Summary
- Add `writingDirection: 'rtl'` to main containers in About and Settings screens for proper Arabic text direction on iOS
- Replace `paddingLeft` with `paddingStart` logical property to respect RTL layout
- Add `flex: 1` to `listText` style to fix Arabic text clipping in flex rows

Tested on iOS Simulator.

Closes #79