### PR TITLE
fix: correct broken camelCase naming in setter variables

### DIFF
--- a/app/(tabs)/(more)/settings.tsx
+++ b/app/(tabs)/(more)/settings.tsx
@@ -30,7 +30,7 @@ export default function SettingsScreen() {
   const [showTrackerNotificationValue, setShowTrackerNotificationValue] =
     useAtom(showTrackerNotification);
   const notificationOptions = ['تعطيل', 'حزب', 'جزء'];
-  const [HizbNotificationValue, setHizbNotificationValue] =
+  const [hizbNotificationValue, setHizbNotificationValue] =
     useAtom(hizbNotification);
   const { textColor, primaryColor, cardColor, iconColor } = useColors();
   const [mushafContrastValue, setMushafContrastValue] = useAtom(mushafContrast);
@@ -205,7 +205,7 @@ export default function SettingsScreen() {
         <Pressable style={styles.fullWidth} accessibilityRole="radiogroup">
           <SegmentedControlWithDisabled
             options={notificationOptions}
-            initialSelectedIndex={HizbNotificationValue}
+            initialSelectedIndex={hizbNotificationValue}
             activeColor={primaryColor}
             textColor={primaryColor}
             disabledTextColor={primaryColor}

--- a/app/tracker.tsx
+++ b/app/tracker.tsx
@@ -31,9 +31,9 @@ export default function TrackerScreen() {
 
   const { updateAndroidWidget } = useUpdateAndroidWidget();
 
-  const [dailyTrackerGoalValue, setdailyTrackerGoalValue] =
+  const [dailyTrackerGoalValue, setDailyTrackerGoalValue] =
     useAtom(dailyTrackerGoal);
-  const [dailyTrackerCompletedValue, setdailyTrackerCompletedValue] = useAtom(
+  const [dailyTrackerCompletedValue, setDailyTrackerCompletedValue] = useAtom(
     dailyTrackerCompleted,
   );
   const [yesterdayPageValue, setYesterdayPageValue] = useAtom(yesterdayPage);
@@ -50,9 +50,9 @@ export default function TrackerScreen() {
       : 0;
 
   // Should change by full hizb (8 thumns)
-  const incrementDailyGoal = () => setdailyTrackerGoalValue((prev) => prev + 1);
+  const incrementDailyGoal = () => setDailyTrackerGoalValue((prev) => prev + 1);
   const decrementDailyGoal = () =>
-    setdailyTrackerGoalValue((prev) => Math.max(1, prev - 1));
+    setDailyTrackerGoalValue((prev) => Math.max(1, prev - 1));
 
   // Consolidated reset logic into one function
   const performReset = async () => {
@@ -63,7 +63,7 @@ export default function TrackerScreen() {
       });
     }
 
-    setdailyTrackerCompletedValue({
+    setDailyTrackerCompletedValue({
       value: 0,
       date: new Date().toDateString(),
     });

--- a/components/MushafPage.tsx
+++ b/components/MushafPage.tsx
@@ -54,7 +54,7 @@ export default function MushafPage() {
   const hizbNotificationValue = useAtomValue(hizbNotification);
   const [showHizbNotification, setShowHizbNotification] = useState(false);
 
-  const setdailyTrackerCompletedValue = useSetAtom(dailyTrackerCompleted);
+  const setDailyTrackerCompletedValue = useSetAtom(dailyTrackerCompleted);
 
   const showTrackerNotificationValue = useAtomValue(showTrackerNotification);
   const [showGoalNotification, setShowGoalNotification] = useState(false);
@@ -270,7 +270,7 @@ export default function MushafPage() {
       );
 
       // Update the progress state with new object format
-      setdailyTrackerCompletedValue({
+      setDailyTrackerCompletedValue({
         value: numberOfThumn / 8,
         date: new Date().toDateString(),
       });
@@ -279,7 +279,7 @@ export default function MushafPage() {
     currentPage,
     yesterdayPageValue,
     thumnData,
-    setdailyTrackerCompletedValue,
+    setDailyTrackerCompletedValue,
   ]);
 
   // Handle errors from metadata loading


### PR DESCRIPTION
## Summary

- Renames 3 Jotai setter/value variables that violated camelCase naming convention across 3 files
- `setdailyTrackerGoalValue` → `setDailyTrackerGoalValue` in `app/tracker.tsx`
- `setdailyTrackerCompletedValue` → `setDailyTrackerCompletedValue` in `app/tracker.tsx` and `components/MushafPage.tsx`
- `HizbNotificationValue` → `hizbNotificationValue` in `app/(tabs)/(more)/settings.tsx`

## Details

These are purely local variable renames — no logic changes, no persistence/storage key changes, no API contract changes. The Jotai atom names (`dailyTrackerGoal`, `dailyTrackerCompleted`, `hizbNotification`) and their storage keys (`'DailyTrackerGoal'`, `'DailyTrackerCompleted'`, `'HizbNotification'`) are unchanged.

## Test plan

- [x] `npx tsc --noEmit` — zero errors in changed files (7 pre-existing errors in unrelated files unchanged)
- [x] `pnpm lint` — zero errors in changed files (14 pre-existing errors in unrelated files unchanged)
- [x] Pre-commit hooks (prettier + eslint --fix) pass
- [x] Grep confirms zero remaining broken-camelCase setter names in codebase
- [x] Git diff confirms pure rename (10 insertions, 10 deletions, only casing changes)

Closes #30

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**ITQAN Ramadan Al-Athar Contribution**
- Issue: #30 (Inconsistent Naming Conventions)
- Points: 100
- Contributor: @Hashem-Al-Qurashi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code consistency by standardizing naming conventions across internal state management throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->