### PR TITLE
feat: add deep link + app store fallback for mobile web users

### DIFF
--- a/app.json
+++ b/app.json
@@ -7,7 +7,7 @@
     "orientation": "default",
     "assetBundlePatterns": ["**/*"],
     "icon": "./assets/images/icon.png",
-    "scheme": "myapp",
+    "scheme": "openmushaf",
     "userInterfaceStyle": "automatic",
     "newArchEnabled": true,
     "ios": {
@@ -31,6 +31,14 @@
           },
           "category": ["BROWSABLE", "DEFAULT"],
           "autoVerify": true
+        },
+        {
+          "action": "VIEW",
+          "data": {
+            "scheme": "openmushaf",
+            "host": "mushaf"
+          },
+          "category": ["BROWSABLE", "DEFAULT"]
         }
       ],
       "softwareKeyboardLayoutMode": "resize",

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -29,6 +29,7 @@ import { HelmetProvider } from 'react-helmet-async';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context';
 
+import DeepLinkBanner from '@/components/DeepLinkBanner';
 import Notification from '@/components/Notification';
 import SEO from '@/components/seo';
 import { isRTL } from '@/utils';
@@ -142,6 +143,7 @@ export default function RootLayout() {
                   />
                 </Stack>
                 <Notification />
+                <DeepLinkBanner />
               </ThemeProvider>
             </SafeAreaView>
           </SafeAreaProvider>

--- a/components/DeepLinkBanner.tsx
+++ b/components/DeepLinkBanner.tsx
@@ -1,0 +1,158 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  Linking,
+  Platform,
+  Pressable,
+  StyleSheet,
+  View,
+} from 'react-native';
+
+import Animated, { SlideInDown, SlideOutDown } from 'react-native-reanimated';
+
+import { ThemedText } from '@/components/ThemedText';
+import { useColors } from '@/hooks/useColors';
+
+const DEEP_LINK_URL = 'openmushaf://mushaf';
+const PLAY_STORE_URL =
+  'https://play.google.com/store/apps/details?id=com.adelpro.openmushafnative';
+
+type MobilePlatform = 'android' | 'ios' | null;
+
+function detectMobilePlatform(): MobilePlatform {
+  if (Platform.OS !== 'web') return null;
+  if (typeof navigator === 'undefined') return null;
+
+  const ua = navigator.userAgent.toLowerCase();
+  if (/android/i.test(ua)) return 'android';
+  if (/iphone|ipad|ipod/i.test(ua)) return 'ios';
+  return null;
+}
+
+export default function DeepLinkBanner() {
+  const [visible, setVisible] = useState(false);
+  const [platform, setPlatform] = useState<MobilePlatform>(null);
+  const { primaryColor, cardColor, textColor } = useColors();
+
+  useEffect(() => {
+    if (Platform.OS !== 'web') return;
+
+    const detected = detectMobilePlatform();
+    if (!detected) return;
+
+    const dismissed = sessionStorage.getItem('deep-link-banner-dismissed');
+    if (dismissed) return;
+
+    setPlatform(detected);
+    setVisible(true);
+  }, []);
+
+  const handleOpenApp = useCallback(() => {
+    window.location.href = DEEP_LINK_URL;
+
+    if (platform === 'android') {
+      setTimeout(() => {
+        Linking.openURL(PLAY_STORE_URL);
+      }, 1500);
+    }
+  }, [platform]);
+
+  const handleDismiss = useCallback(() => {
+    sessionStorage.setItem('deep-link-banner-dismissed', 'true');
+    setVisible(false);
+  }, []);
+
+  if (!visible) return null;
+
+  return (
+    <Animated.View
+      entering={SlideInDown}
+      exiting={SlideOutDown}
+      style={[styles.container, { backgroundColor: cardColor }]}
+    >
+      <View style={styles.content}>
+        <ThemedText style={styles.message}>
+          {'تجربة أفضل في التطبيق'}
+        </ThemedText>
+        {platform === 'ios' && (
+          <ThemedText style={styles.subMessage}>
+            {'التطبيق قريبًا على App Store'}
+          </ThemedText>
+        )}
+        <View style={styles.actions}>
+          {platform === 'android' && (
+            <Pressable
+              onPress={handleOpenApp}
+              style={[styles.button, { backgroundColor: primaryColor }]}
+            >
+              <ThemedText style={styles.buttonText}>
+                {'فتح التطبيق'}
+              </ThemedText>
+            </Pressable>
+          )}
+          <Pressable onPress={handleDismiss} style={styles.dismissButton}>
+            <ThemedText style={[styles.dismissText, { color: textColor }]}>
+              {'لاحقًا'}
+            </ThemedText>
+          </Pressable>
+        </View>
+      </View>
+    </Animated.View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    position: 'absolute',
+    bottom: 0,
+    left: 0,
+    right: 0,
+    zIndex: 999,
+    borderTopWidth: 1,
+    borderTopColor: 'rgba(0,0,0,0.1)',
+    elevation: 5,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: -2 },
+    shadowOpacity: 0.1,
+    shadowRadius: 4,
+  },
+  content: {
+    padding: 16,
+    alignItems: 'center',
+    gap: 8,
+  },
+  message: {
+    fontSize: 16,
+    fontFamily: 'Tajawal_500Medium',
+    textAlign: 'center',
+  },
+  subMessage: {
+    fontSize: 13,
+    fontFamily: 'Tajawal_400Regular',
+    textAlign: 'center',
+    opacity: 0.7,
+  },
+  actions: {
+    flexDirection: 'row',
+    gap: 12,
+    alignItems: 'center',
+  },
+  button: {
+    paddingHorizontal: 20,
+    paddingVertical: 8,
+    borderRadius: 8,
+  },
+  buttonText: {
+    color: '#FFFFFF',
+    fontSize: 14,
+    fontFamily: 'Tajawal_500Medium',
+  },
+  dismissButton: {
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+  },
+  dismissText: {
+    fontSize: 14,
+    fontFamily: 'Tajawal_400Regular',
+    opacity: 0.7,
+  },
+});


### PR DESCRIPTION
## Summary

Adds a dismissible banner for mobile web users suggesting they open or install the native app, with deep link support and Play Store fallback.

Closes #139

## Changes

- **New component**: `components/DeepLinkBanner.tsx` — detects mobile web visitors (Android/iOS) via user agent, shows a bottom banner with "Open App" (Android) or "Coming soon to App Store" (iOS) messaging
- **Updated `app/_layout.tsx`**: renders `DeepLinkBanner` inside the root layout
- **Updated `app.json`**: changed scheme from `myapp` to `openmushaf`, added `openmushaf://mushaf` intent filter for Android deep linking

## Behavior

1. Only shown on web platform when visiting from a mobile browser
2. Detects Android vs iOS via user agent
3. Android users see "Open App" button — tries `openmushaf://mushaf` deep link first, falls back to Play Store after 1.5s
4. iOS users see a "Coming soon to App Store" message
5. Dismissed via "Later" button, stored in `sessionStorage` so it only appears once per session
6. Uses existing theme colors and Tajawal font family for consistency
7. Animated entry/exit using `react-native-reanimated` (SlideInDown/SlideOutDown)

## Test plan

- [ ] Open the web app on an Android phone browser — banner should appear at bottom
- [ ] Tap "Open App" — should attempt deep link, then redirect to Play Store
- [ ] Tap "Later" — banner dismisses and does not reappear for the session
- [ ] Refresh the page after dismissing — banner should stay hidden
- [ ] Open in a new session (new tab/incognito) — banner should appear again
- [ ] Open on iOS mobile browser — banner shows with "Coming soon" message, no "Open App" button
- [ ] Open on desktop browser — no banner shown
- [ ] Verify the banner respects light/dark theme

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a smart banner on mobile browsers prompting users to open the native app
  * Users can open the app or dismiss the banner with one tap
  * The banner intelligently appears once per session on mobile devices only
  * Improved deep linking functionality for seamless app integration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->