### PR TITLE
test: add tests for reading tracker calculations

### DIFF
--- a/components/ReadingChart/index.tsx
+++ b/components/ReadingChart/index.tsx
@@ -59,6 +59,7 @@ export function ReadingChart() {
     total,
     effectiveAvg,
     recordsWithData,
+    isDemoData,
     period,
     periodIndex,
     setPeriodIndex,
@@ -238,6 +239,16 @@ export function ReadingChart() {
             style={[styles.avgLabel, { color: textColor, opacity: 0.4 }]}
           >
             بدأ التتبع قبل {recordsWithData} يوماً
+          </ThemedText>
+        )}
+        {/* The chart falls back to generated history in Expo Go and in a dev
+            build with no records yet. Label it so the figures above are never
+            mistaken for a real reading history. */}
+        {isDemoData && (
+          <ThemedText
+            style={[styles.avgLabel, { color: textColor, opacity: 0.4 }]}
+          >
+            بيانات تجريبية
           </ThemedText>
         )}
       </ThemedView>

--- a/hooks/useReadingChartData.ts
+++ b/hooks/useReadingChartData.ts
@@ -11,89 +11,19 @@ import {
   readingHistory,
   yesterdayPage,
 } from '@/jotai/atoms';
-import { daysAgo } from '@/utils';
+import {
+  buildDailyRecords,
+  type ChartMetric,
+  daysAgo,
+  getMetricValue,
+  type GroupBy,
+  groupDailyRecords,
+  summarizeReadingStats,
+} from '@/utils';
 
-export type ChartMetric = 'hizbs' | 'pages';
-export type GroupBy = 'day' | 'week' | 'month';
-
-// Sum a slice of daily records into a single weekly bucket. The bucket
-// inherits its `date` from the last day in the slice (the most recent day
-// in the bucket is the most informative label anchor) and computes
-// `weekStart` by walking back `chunk.length - 1` days from that anchor —
-// using the actual chunk length keeps the range accurate for the partial
-// trailing bucket that appears when the period isn't a multiple of 7
-// (e.g. 30 days → 4 full weeks + 2 days).
-const aggregateWeek = (
-  daily: readonly DailyReadingRecord[],
-): DailyReadingRecord => {
-  const end = new Date(daily[daily.length - 1].date);
-  const start = new Date(end);
-  start.setDate(end.getDate() - (daily.length - 1));
-  return {
-    date: end.toDateString(),
-    weekStart: start.toDateString(),
-    daysInBucket: daily.length,
-    hizbsCompleted: parseFloat(
-      daily.reduce((s, d) => s + d.hizbsCompleted, 0).toFixed(1),
-    ),
-    pagesRead: daily.reduce((s, d) => s + d.pagesRead, 0),
-    // A weekly bucket counts as having a record if at least one underlying
-    // day had one. An empty bucket (user didn't track at all that week)
-    // stays at 0 with hasRecord=false so the chart can render it as "no
-    // data" instead of "read 0".
-    hasRecord: daily.some((d) => d.hasRecord),
-  };
-};
-
-const aggregateByWeek = (
-  daily: readonly DailyReadingRecord[],
-): DailyReadingRecord[] => {
-  const weeks: DailyReadingRecord[] = [];
-  for (let i = 0; i < daily.length; i += 7) {
-    const chunk = daily.slice(i, i + 7);
-    if (chunk.length > 0) weeks.push(aggregateWeek(chunk));
-  }
-  return weeks;
-};
-
-// Sum a slice of daily records into a single 30-day bucket. Same shape as
-// `aggregateWeek` — the bucket inherits its `date` from the last day in the
-// slice and walks back `chunk.length - 1` days to compute the start. Today
-// only the 90-day period exposes `groupBy='month'`, so `chunk.length` is
-// always 30, but the helper accepts partial trailing buckets for robustness
-// (matches the `aggregateWeek` contract so the same `daysInBucket` field
-// drives the partial-bucket visual treatment).
-const aggregateMonth = (
-  daily: readonly DailyReadingRecord[],
-): DailyReadingRecord => {
-  const end = new Date(daily[daily.length - 1].date);
-  const start = new Date(end);
-  start.setDate(end.getDate() - (daily.length - 1));
-  return {
-    date: end.toDateString(),
-    weekStart: start.toDateString(), // bucket start; re-using the field
-    daysInBucket: daily.length,
-    hizbsCompleted: parseFloat(
-      daily.reduce((s, d) => s + d.hizbsCompleted, 0).toFixed(1),
-    ),
-    pagesRead: daily.reduce((s, d) => s + d.pagesRead, 0),
-    // Mirror `aggregateWeek`: a monthly bucket counts as recorded if any
-    // day inside it had a record. Keeps the "no data" vs "read 0"
-    // distinction intact when the user is partway through a 30-day bucket.
-    hasRecord: daily.some((d) => d.hasRecord),
-  };
-};
-
-const aggregateByMonth = (
-  daily: readonly DailyReadingRecord[],
-): DailyReadingRecord[] => {
-  const months: DailyReadingRecord[] = [];
-  for (let i = 0; i < daily.length; i += 30) {
-    const chunk = daily.slice(i, i + 30);
-    if (chunk.length > 0) months.push(aggregateMonth(chunk));
-  }
-  return months;
-};
+// Re-exported so consumers keep importing these from `@/hooks` — the chart
+// component and its props are typed against them.
+export type { ChartMetric, GroupBy };
 
 // `Constants.executionEnvironment` is `'storeClient'` only when running inside
 // Expo Go (the `expo start` dev client). In Expo Go, `react-native-mmkv` v3
@@ -107,6 +37,9 @@ const isExpoGo = Constants.executionEnvironment === 'storeClient';
 /**
  * Hook to aggregate and calculate user reading metrics for visualization in charts.
  * Processes Jotai store history against the selected tracking metric.
+ *
+ * The calculations themselves live in `@/utils/readingStats` as pure
+ * functions; this hook only wires the atoms and the period state to them.
  *
  * @param metric - The unit of measurement for charting data ('hizbs' | 'pages'). Defaults to 'hizbs'.
  * @param groupBy - Granularity for bar rendering. `'day'` (default) shows one bar per day; `'week'` buckets days into 7-day totals.
@@ -159,87 +92,31 @@ export function useReadingChartData(
     }
     // ─── END DEV_MOCK ────────────────────────────────────────────────────────
 
-    const hizbMap = new Map<string, number>();
-    const pagesMap = new Map<string, number>();
-    // Track which date strings had a real record. Used both to set
-    // `hasRecord` on each daily slot (so the chart can render "no data"
-    // vs "read 0") and to derive `trackingStartedAt` (the earliest date
-    // with a record in the current window).
-    const recordedDates = new Set<string>();
-
-    for (const entry of history) {
-      hizbMap.set(entry.date, entry.hizbsCompleted);
-      pagesMap.set(entry.date, entry.pagesRead ?? 0);
-      recordedDates.add(entry.date);
-    }
-
-    hizbMap.set(todayTracker.date, todayTracker.value);
-    pagesMap.set(todayTracker.date, todayPagesRead);
-    recordedDates.add(todayTracker.date);
-
-    // Build daily records for the current period
-    const result: DailyReadingRecord[] = [];
-    for (let i = period - 1; i >= 0; i--) {
-      const dateStr = daysAgo(i);
-      const hasRecord = recordedDates.has(dateStr);
-      result.push({
-        date: dateStr,
-        hizbsCompleted: hasRecord ? (hizbMap.get(dateStr) ?? 0) : 0,
-        pagesRead: hasRecord ? (pagesMap.get(dateStr) ?? 0) : 0,
-        hasRecord,
-      });
-    }
-    return result;
+    return buildDailyRecords(history, todayTracker, todayPagesRead, period);
   }, [history, todayTracker, todayPagesRead, period]);
 
   // When grouping by week/month, the series collapses to chunked totals.
   const chartData = useMemo(
-    () =>
-      groupBy === 'week'
-        ? aggregateByWeek(data)
-        : groupBy === 'month'
-          ? aggregateByMonth(data)
-          : data,
+    () => groupDailyRecords(data, groupBy),
     [groupBy, data],
   );
 
   const getValue = useCallback(
-    (d: DailyReadingRecord) =>
-      metric === 'pages' ? d.pagesRead : d.hizbsCompleted,
+    (d: DailyReadingRecord) => getMetricValue(d, metric),
     [metric],
   );
 
-  const maxValue = useMemo(
-    () => Math.max(1, ...chartData.map(getValue)),
-    [chartData, getValue],
+  const {
+    total,
+    maxValue,
+    avg,
+    effectiveAvg,
+    recordsWithData,
+    trackingStartedAt,
+  } = useMemo(
+    () => summarizeReadingStats(data, chartData, metric, groupBy),
+    [data, chartData, metric, groupBy],
   );
-
-  const total = useMemo(
-    () => chartData.reduce((sum, d) => sum + getValue(d), 0),
-    [chartData, getValue],
-  );
-
-  // Average: per-day when grouping is 'day', per-week when 'week'. Using
-  // `chartData.length` keeps the denominator correct even when the
-  // last bucket is partial (e.g. 90 days / 7 = 12 full weeks + 6 days).
-  const unitCount = chartData.length || 1;
-  const avg = total / unitCount;
-
-  // For the daily view only, recompute the average excluding buckets with
-  // no record so a user who started tracking 22 days ago doesn't see
-  // their 1-hizb/day pace reported as 0.24 hizb/day. Weekly/monthly
-  // averages already collapse the unrecorded stretch into zero-totals
-  // within each bucket, so we keep the simpler `avg` there.
-  const recordsWithData = data.filter((d) => d.hasRecord).length;
-  const effectiveAvg =
-    groupBy === 'day' && recordsWithData > 0 ? total / recordsWithData : avg;
-
-  // `trackingStartedAt` is the earliest recorded date in the current
-  // window — `null` when the user has no records at all (the empty state
-  // handles that). Rendered as a small caption so users who haven't yet
-  // filled the full 90-day window know the chart isn't missing data.
-  const trackingStartedAt =
-    recordsWithData > 0 ? (data.find((d) => d.hasRecord)?.date ?? null) : null;
 
   return {
     data: chartData,

--- a/hooks/useReadingChartData.ts
+++ b/hooks/useReadingChartData.ts
@@ -67,32 +67,33 @@ export function useReadingChartData(
     //      developer to see a populated chart while building the UI.
     // The mock must never override real data, so `history.length === 0` is a
     // hard requirement in both cases.
+    //
+    // The mock fabricates *history* — the same shape `readingHistory` holds —
+    // and then runs through `buildDailyRecords` exactly like the real path.
+    // Skipped days are left out of the array rather than pushed as zeros, so
+    // `hasRecord` is derived by `buildDailyRecords` instead of hardcoded here.
+    // Dev therefore exercises the production code path and shows the real
+    // untracked-vs-read-nothing distinction.
+    let source: readonly DailyReadingRecord[] = history;
     if ((isExpoGo || __DEV__) && history.length === 0) {
       const seed = (n: number) =>
         Math.abs(Math.sin(n * 9301 + 49297) * 233280) % 1;
-      const result: DailyReadingRecord[] = [];
-      for (let i = period - 1; i >= 0; i--) {
-        const dateStr = daysAgo(i);
-        const skip = seed(i) > 0.78; // ~22% of days have no reading
-        const hizbs = skip ? 0 : parseFloat((seed(i + 1) * 3 + 0.5).toFixed(1));
-        const pages = skip ? 0 : Math.round(seed(i + 2) * 12 + 1);
-        // In the dev mock every slot is "recorded" — `skip` toggles the
-        // *value* to zero but the slot itself is part of the synthetic
-        // dataset, so hasRecord stays true. This keeps the chart visually
-        // full during dev (no dashed-outline gaps) while production still
-        // gets the no-record treatment for untracked days.
-        result.push({
-          date: dateStr,
-          hizbsCompleted: hizbs,
-          pagesRead: pages,
-          hasRecord: true,
+      const mockHistory: DailyReadingRecord[] = [];
+      // Today is deliberately omitted: `buildDailyRecords` always takes it
+      // from the live tracker, so an entry here would just be overwritten.
+      for (let i = period - 1; i >= 1; i--) {
+        if (seed(i) > 0.78) continue; // ~22% of days were never tracked
+        mockHistory.push({
+          date: daysAgo(i),
+          hizbsCompleted: parseFloat((seed(i + 1) * 3 + 0.5).toFixed(1)),
+          pagesRead: Math.round(seed(i + 2) * 12 + 1),
         });
       }
-      return result;
+      source = mockHistory;
     }
     // ─── END DEV_MOCK ────────────────────────────────────────────────────────
 
-    return buildDailyRecords(history, todayTracker, todayPagesRead, period);
+    return buildDailyRecords(source, todayTracker, todayPagesRead, period);
   }, [history, todayTracker, todayPagesRead, period]);
 
   // When grouping by week/month, the series collapses to chunked totals.

--- a/hooks/useReadingChartData.ts
+++ b/hooks/useReadingChartData.ts
@@ -58,6 +58,11 @@ export function useReadingChartData(
 
   const todayPagesRead = Math.max(0, (savedPage as number) - yesterday.value);
 
+  // True when the chart is fed generated demo history instead of the user's
+  // own records. Returned so the UI can label the stats as demo data rather
+  // than letting a developer read them as a real reading history.
+  const isDemoData = (isExpoGo || __DEV__) && history.length === 0;
+
   const data: DailyReadingRecord[] = useMemo(() => {
     // ─── DEV_MOCK: only used in Expo Go or with no real history ───────────────
     // Two paths can land us here:
@@ -75,7 +80,7 @@ export function useReadingChartData(
     // Dev therefore exercises the production code path and shows the real
     // untracked-vs-read-nothing distinction.
     let source: readonly DailyReadingRecord[] = history;
-    if ((isExpoGo || __DEV__) && history.length === 0) {
+    if (isDemoData) {
       const seed = (n: number) =>
         Math.abs(Math.sin(n * 9301 + 49297) * 233280) % 1;
       const mockHistory: DailyReadingRecord[] = [];
@@ -94,7 +99,7 @@ export function useReadingChartData(
     // ─── END DEV_MOCK ────────────────────────────────────────────────────────
 
     return buildDailyRecords(source, todayTracker, todayPagesRead, period);
-  }, [history, todayTracker, todayPagesRead, period]);
+  }, [history, todayTracker, todayPagesRead, period, isDemoData]);
 
   // When grouping by week/month, the series collapses to chunked totals.
   const chartData = useMemo(
@@ -127,6 +132,7 @@ export function useReadingChartData(
     effectiveAvg,
     recordsWithData,
     trackingStartedAt,
+    isDemoData,
     period,
     periodIndex,
     setPeriodIndex,

--- a/utils/__tests__/readingChart.test.ts
+++ b/utils/__tests__/readingChart.test.ts
@@ -1,0 +1,302 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { daysAgo, formatLabel, shouldShowLabel } from '@/utils/readingChart';
+
+// `formatLabel` renders month names and digits through `Intl`, which follows
+// the *device* locale — Arabic on an Arabic phone, English in CI. Asserting
+// literal strings would make these tests pass or fail based on the runner's
+// ICU default, so the expectations are built with the same Intl calls the
+// implementation uses. What is under test is *which* month and *which*
+// number the label picks, not how the platform spells them.
+const monthName = (year: number, month: number) =>
+  new Intl.DateTimeFormat(undefined, { month: 'long' }).format(
+    new Date(year, month, 15),
+  );
+const digits = (n: number) => new Intl.NumberFormat(undefined).format(n);
+
+/** `toDateString()` for a local calendar date, the format the chart stores. */
+const dateStr = (year: number, month: number, dayOfMonth: number) =>
+  new Date(year, month, dayOfMonth).toDateString();
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('formatLabel', () => {
+  describe('7-day period', () => {
+    // Sun Jun 14 2026 through Sat Jun 20 2026 is a full week.
+    const WEEKDAYS = ['أحد', 'إثنين', 'ثلاث', 'أربع', 'خميس', 'جمعة', 'سبت'];
+
+    it('labels each day with its Arabic weekday name', () => {
+      WEEKDAYS.forEach((name, i) => {
+        expect(formatLabel({ date: dateStr(2026, 5, 14 + i) }, 7)).toEqual({
+          primary: name,
+        });
+      });
+    });
+
+    it('keeps weekday names even if a grouping is passed', () => {
+      // The group-by toggle is hidden below 8 days, but a stale selection
+      // must not change the axis.
+      expect(
+        formatLabel(
+          { date: dateStr(2026, 5, 15), weekStart: dateStr(2026, 5, 9) },
+          7,
+          'week',
+        ),
+      ).toEqual({ primary: 'إثنين' });
+    });
+  });
+
+  describe('daily bars', () => {
+    it('shows the day of the month for a 30-day period', () => {
+      expect(formatLabel({ date: dateStr(2026, 5, 8) }, 30)).toEqual({
+        primary: digits(8),
+      });
+    });
+
+    it('shows month/day for a 90-day period', () => {
+      expect(formatLabel({ date: dateStr(2026, 5, 8) }, 90)).toEqual({
+        primary: `${digits(6)}/${digits(8)}`,
+      });
+    });
+  });
+
+  describe('weekly bars', () => {
+    it('labels a full in-month week as a bare day range', () => {
+      expect(
+        formatLabel(
+          {
+            date: dateStr(2026, 5, 13),
+            weekStart: dateStr(2026, 5, 7),
+            daysInBucket: 7,
+          },
+          30,
+          'week',
+        ),
+      ).toEqual({
+        primary: `${digits(7)}-${digits(13)}`,
+        secondary: undefined,
+      });
+    });
+
+    it('names the end month when the week crosses a month boundary', () => {
+      // Sun Jun 28 2026 → Sat Jul 04 2026.
+      expect(
+        formatLabel(
+          {
+            date: dateStr(2026, 6, 4),
+            weekStart: dateStr(2026, 5, 28),
+            daysInBucket: 7,
+          },
+          30,
+          'week',
+        ),
+      ).toEqual({
+        primary: `${digits(28)}-${digits(4)}`,
+        secondary: monthName(2026, 6),
+      });
+    });
+
+    it('captions a short trailing bucket with its day count', () => {
+      expect(
+        formatLabel(
+          {
+            date: dateStr(2026, 5, 15),
+            weekStart: dateStr(2026, 5, 14),
+            daysInBucket: 2,
+          },
+          30,
+          'week',
+        ),
+      ).toEqual({
+        primary: `${digits(14)}-${digits(15)}`,
+        secondary: `${digits(2)} أيام`,
+      });
+    });
+
+    it('prefers the month name over the day count when both apply', () => {
+      // A partial bucket that also crosses into July: only one secondary
+      // line fits, and the month is the more useful signal.
+      expect(
+        formatLabel(
+          {
+            date: dateStr(2026, 6, 2),
+            weekStart: dateStr(2026, 5, 30),
+            daysInBucket: 3,
+          },
+          90,
+          'week',
+        ).secondary,
+      ).toBe(monthName(2026, 6));
+    });
+
+    it('falls back to the end date when no weekStart is present', () => {
+      expect(formatLabel({ date: dateStr(2026, 5, 15) }, 30, 'week')).toEqual({
+        primary: `${digits(15)}-${digits(15)}`,
+        secondary: undefined,
+      });
+    });
+  });
+
+  describe('monthly bars', () => {
+    it('names the end month when the bucket crosses a month boundary', () => {
+      // A 30-day bucket practically always spans two calendar months.
+      expect(
+        formatLabel(
+          {
+            date: dateStr(2026, 5, 15),
+            weekStart: dateStr(2026, 4, 17),
+            daysInBucket: 30,
+          },
+          90,
+          'month',
+        ),
+      ).toEqual({
+        primary: `${digits(17)}-${digits(15)}`,
+        secondary: monthName(2026, 5),
+      });
+    });
+
+    it('prefers the year over the month across a year boundary', () => {
+      // Thu Dec 18 2025 → Fri Jan 16 2026: the year is the only label that
+      // disambiguates this bucket from the same dates a year earlier.
+      expect(
+        formatLabel(
+          {
+            date: dateStr(2026, 0, 16),
+            weekStart: dateStr(2025, 11, 18),
+            daysInBucket: 30,
+          },
+          90,
+          'month',
+        ),
+      ).toEqual({
+        primary: `${digits(18)}-${digits(16)}`,
+        secondary: digits(2026),
+      });
+    });
+
+    it('captions a short trailing bucket that stays inside one month', () => {
+      expect(
+        formatLabel(
+          {
+            date: dateStr(2026, 5, 10),
+            weekStart: dateStr(2026, 5, 1),
+            daysInBucket: 10,
+          },
+          90,
+          'month',
+        ),
+      ).toEqual({
+        primary: `${digits(1)}-${digits(10)}`,
+        secondary: `${digits(10)} أيام`,
+      });
+    });
+
+    it('adds no caption to a full in-month bucket', () => {
+      expect(
+        formatLabel(
+          {
+            date: dateStr(2026, 0, 30),
+            weekStart: dateStr(2026, 0, 1),
+            daysInBucket: 30,
+          },
+          90,
+          'month',
+        ).secondary,
+      ).toBeUndefined();
+    });
+  });
+});
+
+describe('shouldShowLabel', () => {
+  it('labels every bar of a 7-day period', () => {
+    for (let i = 0; i < 7; i++) {
+      expect(shouldShowLabel(dateStr(2026, 5, 9 + i), i, 7)).toBe(true);
+    }
+  });
+
+  it('labels every fifth bar plus the last one at 30 days', () => {
+    const shown = Array.from({ length: 30 }, (_, i) =>
+      shouldShowLabel(dateStr(2026, 5, 1), i, 30),
+    )
+      .map((visible, i) => (visible ? i : -1))
+      .filter((i) => i >= 0);
+
+    expect(shown).toEqual([0, 5, 10, 15, 20, 25, 29]);
+  });
+
+  it('anchors 90-day labels to the 1st, the 15th, and the final bar', () => {
+    expect(shouldShowLabel(dateStr(2026, 5, 1), 12, 90)).toBe(true);
+    expect(shouldShowLabel(dateStr(2026, 5, 15), 26, 90)).toBe(true);
+    expect(shouldShowLabel(dateStr(2026, 5, 7), 18, 90)).toBe(false);
+    // The most recent bar is always labelled, whatever date it falls on.
+    expect(shouldShowLabel(dateStr(2026, 5, 7), 89, 90)).toBe(true);
+  });
+
+  it('labels every grouped bucket regardless of period', () => {
+    // Grouped views have at most ~13 bars, so thinning them would leave most
+    // buckets unlabelled.
+    expect(shouldShowLabel(dateStr(2026, 5, 7), 3, 90, 'week')).toBe(true);
+    expect(shouldShowLabel(dateStr(2026, 5, 7), 1, 90, 'month')).toBe(true);
+  });
+});
+
+describe('daysAgo', () => {
+  const freeze = (year: number, month: number, dayOfMonth: number) => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(year, month, dayOfMonth, 12, 0, 0));
+  };
+
+  it('returns today for an offset of zero', () => {
+    freeze(2026, 5, 15);
+
+    expect(daysAgo(0)).toBe(dateStr(2026, 5, 15));
+  });
+
+  it('walks back across a month boundary', () => {
+    freeze(2026, 5, 1); // Mon Jun 01 2026
+
+    expect(daysAgo(1)).toBe(dateStr(2026, 4, 31));
+    expect(daysAgo(2)).toBe(dateStr(2026, 4, 30));
+  });
+
+  it('walks back across a year boundary', () => {
+    freeze(2026, 0, 1); // Thu Jan 01 2026
+
+    expect(daysAgo(1)).toBe(dateStr(2025, 11, 31));
+    expect(daysAgo(1)).toContain('2025');
+  });
+
+  it('walks back across a leap day', () => {
+    freeze(2028, 2, 1); // Wed Mar 01 2028, a leap year
+
+    expect(daysAgo(1)).toBe(dateStr(2028, 1, 29));
+  });
+
+  it('produces a contiguous run over a full 90-day window', () => {
+    freeze(2026, 5, 15);
+
+    const dates = Array.from({ length: 90 }, (_, i) => daysAgo(89 - i));
+
+    expect(new Set(dates).size).toBe(90);
+    expect(dates[89]).toBe(dateStr(2026, 5, 15));
+    dates.forEach((d, i) => {
+      if (i === 0) return;
+      const gap = Date.parse(d) - Date.parse(dates[i - 1]);
+      expect(gap).toBe(24 * 60 * 60 * 1000);
+    });
+  });
+
+  it('is unaffected by the time of day', () => {
+    freeze(2026, 5, 15);
+    const atNoon = daysAgo(1);
+
+    vi.setSystemTime(new Date(2026, 5, 15, 23, 59, 59));
+    expect(daysAgo(1)).toBe(atNoon);
+
+    vi.setSystemTime(new Date(2026, 5, 15, 0, 0, 1));
+    expect(daysAgo(1)).toBe(atNoon);
+  });
+});

--- a/utils/__tests__/readingStats.test.ts
+++ b/utils/__tests__/readingStats.test.ts
@@ -1,0 +1,407 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { DailyReadingRecord } from '@/jotai/atoms';
+import {
+  buildDailyRecords,
+  getMetricValue,
+  groupDailyRecords,
+  summarizeReadingStats,
+} from '@/utils/readingStats';
+
+// A fixed "now" so every `daysAgo` call in these tests is deterministic.
+// Noon local time keeps the arithmetic clear of DST transitions, which are
+// exercised separately in readingChart.test.ts.
+const NOW = new Date(2026, 5, 15, 12, 0, 0); // Mon Jun 15 2026
+
+/** The date string `n` days before the frozen "now". */
+const day = (n: number) => {
+  const d = new Date(NOW);
+  d.setDate(d.getDate() - n);
+  return d.toDateString();
+};
+
+/** A recorded day. Omitted fields default to zero. */
+const record = (
+  daysBack: number,
+  hizbsCompleted = 0,
+  pagesRead = 0,
+): DailyReadingRecord => ({
+  date: day(daysBack),
+  hizbsCompleted,
+  pagesRead,
+});
+
+/** `count` consecutive tracked days, oldest first, all with the same values. */
+const trackedRun = (
+  count: number,
+  hizbsCompleted: number,
+  pagesRead: number,
+): DailyReadingRecord[] =>
+  Array.from({ length: count }, (_, i) => ({
+    date: day(count - 1 - i),
+    hizbsCompleted,
+    pagesRead,
+    hasRecord: true,
+  }));
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(NOW);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('buildDailyRecords', () => {
+  const tracker = { value: 0, date: day(0) };
+
+  it('returns one slot per day, oldest first, ending today', () => {
+    const result = buildDailyRecords([], tracker, 0, 7);
+
+    expect(result).toHaveLength(7);
+    expect(result[0].date).toBe(day(6));
+    expect(result[6].date).toBe(day(0));
+    expect(result.map((r) => r.date)).toEqual(
+      [6, 5, 4, 3, 2, 1, 0].map((n) => day(n)),
+    );
+  });
+
+  it('marks untracked days as having no record, not as zero reading', () => {
+    const result = buildDailyRecords([record(3, 2, 10)], tracker, 0, 7);
+
+    const tracked = result.find((r) => r.date === day(3));
+    const untracked = result.find((r) => r.date === day(4));
+
+    expect(tracked).toMatchObject({
+      hasRecord: true,
+      hizbsCompleted: 2,
+      pagesRead: 10,
+    });
+    expect(untracked).toMatchObject({
+      hasRecord: false,
+      hizbsCompleted: 0,
+      pagesRead: 0,
+    });
+  });
+
+  it('keeps a stored zero-page day as a real record', () => {
+    // A day the user opened the app but read nothing is meaningfully
+    // different from a day before they started tracking: same zero value,
+    // but `hasRecord` stays true so it still counts toward the average.
+    const result = buildDailyRecords([record(2, 0, 0)], tracker, 0, 7);
+
+    expect(result.find((r) => r.date === day(2))).toMatchObject({
+      hasRecord: true,
+      hizbsCompleted: 0,
+      pagesRead: 0,
+    });
+  });
+
+  it("takes today's figures from the live tracker, not from history", () => {
+    // History can hold a stale entry for today; the tracker is authoritative
+    // until the day rolls over and the entry is rewritten.
+    const stale = [record(0, 1, 5)];
+    const result = buildDailyRecords(stale, { value: 3, date: day(0) }, 12, 7);
+
+    expect(result[6]).toMatchObject({
+      date: day(0),
+      hizbsCompleted: 3,
+      pagesRead: 12,
+      hasRecord: true,
+    });
+  });
+
+  it("records today even when the tracker's value is zero", () => {
+    const result = buildDailyRecords([], tracker, 0, 7);
+
+    expect(result[6]).toMatchObject({ date: day(0), hasRecord: true });
+  });
+
+  it('ignores history entries that fall outside the window', () => {
+    const result = buildDailyRecords([record(40, 5, 20)], tracker, 0, 7);
+
+    expect(result).toHaveLength(7);
+    expect(result.filter((r) => r.hasRecord)).toHaveLength(1); // today only
+    expect(result.some((r) => r.hizbsCompleted === 5)).toBe(false);
+  });
+
+  it('defaults a legacy record with no pagesRead to zero pages', () => {
+    // `pagesRead` was added after `hizbsCompleted`; records persisted by an
+    // older build can be missing it.
+    const legacy = { date: day(2), hizbsCompleted: 1.5 } as DailyReadingRecord;
+    const result = buildDailyRecords([legacy], tracker, 0, 7);
+
+    expect(result.find((r) => r.date === day(2))).toMatchObject({
+      hasRecord: true,
+      hizbsCompleted: 1.5,
+      pagesRead: 0,
+    });
+  });
+
+  it('rolls the window forward when the day changes', () => {
+    const history = [record(0, 2, 8)];
+    const before = buildDailyRecords(history, { value: 2, date: day(0) }, 8, 7);
+
+    // Midnight passes: yesterday's tracker value has been written to history
+    // and today starts fresh at zero.
+    vi.setSystemTime(new Date(2026, 5, 16, 9, 0, 0));
+    const todayStr = new Date(2026, 5, 16).toDateString();
+    const after = buildDailyRecords(
+      history,
+      { value: 0, date: todayStr },
+      0,
+      7,
+    );
+
+    expect(before[6].date).toBe(day(0));
+    expect(after[6].date).toBe(todayStr);
+    // The day that was "today" is now the second-to-last slot and keeps the
+    // figures that were rolled into history.
+    expect(after[5]).toMatchObject({
+      date: day(0),
+      hizbsCompleted: 2,
+      pagesRead: 8,
+      hasRecord: true,
+    });
+    expect(after[6]).toMatchObject({ hizbsCompleted: 0, pagesRead: 0 });
+    // The oldest day in the window has dropped off.
+    expect(after.some((r) => r.date === before[0].date)).toBe(false);
+  });
+
+  it('spans a month boundary without gaps', () => {
+    vi.setSystemTime(new Date(2026, 6, 2, 12, 0, 0)); // Thu Jul 02 2026
+    const result = buildDailyRecords(
+      [],
+      { value: 0, date: new Date(2026, 6, 2).toDateString() },
+      0,
+      5,
+    );
+
+    expect(result.map((r) => r.date)).toEqual([
+      new Date(2026, 5, 28).toDateString(),
+      new Date(2026, 5, 29).toDateString(),
+      new Date(2026, 5, 30).toDateString(),
+      new Date(2026, 6, 1).toDateString(),
+      new Date(2026, 6, 2).toDateString(),
+    ]);
+  });
+});
+
+describe('groupDailyRecords', () => {
+  it('passes the daily series through unchanged', () => {
+    const daily = trackedRun(30, 1, 4);
+
+    expect(groupDailyRecords(daily, 'day')).toEqual(daily);
+  });
+
+  it('sums whole weeks when the period divides evenly', () => {
+    const weeks = groupDailyRecords(trackedRun(28, 1, 4), 'week');
+
+    expect(weeks).toHaveLength(4);
+    expect(weeks[0]).toMatchObject({
+      hizbsCompleted: 7,
+      pagesRead: 28,
+      daysInBucket: 7,
+      hasRecord: true,
+    });
+    // The bucket is anchored on its last day and spans back to its first.
+    expect(weeks[0].date).toBe(day(21));
+    expect(weeks[0].weekStart).toBe(day(27));
+    expect(weeks[3].date).toBe(day(0));
+    expect(weeks[3].weekStart).toBe(day(6));
+  });
+
+  it('leaves the trailing bucket short when the period is incomplete', () => {
+    // 30 days grouped by week is 4 full weeks plus a 2-day remainder.
+    const weeks = groupDailyRecords(trackedRun(30, 1, 4), 'week');
+
+    expect(weeks).toHaveLength(5);
+    expect(weeks.slice(0, 4).map((w) => w.daysInBucket)).toEqual([7, 7, 7, 7]);
+    expect(weeks[4]).toMatchObject({
+      daysInBucket: 2,
+      hizbsCompleted: 2,
+      pagesRead: 8,
+    });
+    expect(weeks[4].date).toBe(day(0));
+    expect(weeks[4].weekStart).toBe(day(1));
+  });
+
+  it('sums whole months across the 90-day window', () => {
+    const months = groupDailyRecords(trackedRun(90, 0.5, 3), 'month');
+
+    expect(months).toHaveLength(3);
+    expect(months.map((m) => m.daysInBucket)).toEqual([30, 30, 30]);
+    expect(months[2]).toMatchObject({ hizbsCompleted: 15, pagesRead: 90 });
+    expect(months[2].date).toBe(day(0));
+    expect(months[2].weekStart).toBe(day(29));
+  });
+
+  it('leaves a short trailing month bucket for a partial window', () => {
+    const months = groupDailyRecords(trackedRun(70, 1, 2), 'month');
+
+    expect(months.map((m) => m.daysInBucket)).toEqual([30, 30, 10]);
+    expect(months[2]).toMatchObject({ hizbsCompleted: 10, pagesRead: 20 });
+  });
+
+  it('marks a bucket as recorded when any single day inside it is', () => {
+    const daily = trackedRun(7, 0, 0).map((d, i) =>
+      i === 3 ? d : { ...d, hasRecord: false },
+    );
+
+    expect(groupDailyRecords(daily, 'week')[0].hasRecord).toBe(true);
+  });
+
+  it('marks a bucket with no tracked days as having no record', () => {
+    const daily = trackedRun(7, 0, 0).map((d) => ({ ...d, hasRecord: false }));
+
+    expect(groupDailyRecords(daily, 'week')[0]).toMatchObject({
+      hasRecord: false,
+      hizbsCompleted: 0,
+      pagesRead: 0,
+    });
+  });
+
+  it('rounds summed hizbs to one decimal', () => {
+    // 0.1 * 7 is 0.7000000000000001 in binary floating point; the chart
+    // renders the raw value, so the sum is rounded at aggregation time.
+    const weeks = groupDailyRecords(trackedRun(7, 0.1, 0), 'week');
+
+    expect(weeks[0].hizbsCompleted).toBe(0.7);
+  });
+
+  it('returns no buckets for an empty series', () => {
+    expect(groupDailyRecords([], 'week')).toEqual([]);
+    expect(groupDailyRecords([], 'month')).toEqual([]);
+  });
+});
+
+describe('getMetricValue', () => {
+  const rec: DailyReadingRecord = {
+    date: day(0),
+    hizbsCompleted: 2.5,
+    pagesRead: 11,
+  };
+
+  it('reads hizbs by default and pages when asked', () => {
+    expect(getMetricValue(rec, 'hizbs')).toBe(2.5);
+    expect(getMetricValue(rec, 'pages')).toBe(11);
+  });
+});
+
+describe('summarizeReadingStats', () => {
+  /** A window of `period` days where only the newest `tracked` are recorded. */
+  const partialWindow = (period: number, tracked: number) =>
+    buildDailyRecords(
+      Array.from({ length: tracked - 1 }, (_, i) => record(i + 1, 1, 4)),
+      { value: 1, date: day(0) },
+      4,
+      period,
+    );
+
+  it('totals and averages the daily series over the whole window', () => {
+    const daily = partialWindow(10, 10);
+    const stats = summarizeReadingStats(daily, daily, 'hizbs', 'day');
+
+    expect(stats.total).toBe(10);
+    expect(stats.avg).toBe(1);
+    expect(stats.effectiveAvg).toBe(1);
+    expect(stats.recordsWithData).toBe(10);
+    expect(stats.maxValue).toBe(1);
+  });
+
+  it('averages the daily view over recorded days only', () => {
+    // 22 tracked days inside a 90-day window: the honest pace is 1/day, not
+    // 22/90 = 0.24/day.
+    const daily = partialWindow(90, 22);
+    const stats = summarizeReadingStats(daily, daily, 'hizbs', 'day');
+
+    expect(stats.recordsWithData).toBe(22);
+    expect(stats.total).toBe(22);
+    expect(stats.avg).toBeCloseTo(22 / 90, 10);
+    expect(stats.effectiveAvg).toBe(1);
+  });
+
+  it('averages weekly and monthly views per bucket', () => {
+    const daily = partialWindow(28, 28);
+
+    const weekly = groupDailyRecords(daily, 'week');
+    const weekStats = summarizeReadingStats(daily, weekly, 'hizbs', 'week');
+    expect(weekStats.total).toBe(28);
+    expect(weekStats.avg).toBe(7);
+    // Weekly buckets already fold untracked days into their own totals, so
+    // there is no separate recorded-day correction.
+    expect(weekStats.effectiveAvg).toBe(weekStats.avg);
+
+    const monthly = groupDailyRecords(daily, 'month');
+    const monthStats = summarizeReadingStats(daily, monthly, 'hizbs', 'month');
+    expect(monthStats.avg).toBe(28);
+    expect(monthStats.effectiveAvg).toBe(monthStats.avg);
+  });
+
+  it('divides by the real bucket count when the last bucket is partial', () => {
+    const daily = partialWindow(30, 30);
+    const weekly = groupDailyRecords(daily, 'week');
+    const stats = summarizeReadingStats(daily, weekly, 'hizbs', 'week');
+
+    expect(weekly).toHaveLength(5);
+    expect(stats.total).toBe(30);
+    expect(stats.avg).toBe(6); // 30 / 5 buckets, not 30 / 4 full weeks
+  });
+
+  it('counts recorded days from the daily series even when grouped', () => {
+    const daily = partialWindow(90, 22);
+    const monthly = groupDailyRecords(daily, 'month');
+    const stats = summarizeReadingStats(daily, monthly, 'hizbs', 'month');
+
+    expect(monthly).toHaveLength(3);
+    expect(stats.recordsWithData).toBe(22);
+  });
+
+  it('switches totals with the metric', () => {
+    const daily = partialWindow(10, 10);
+
+    expect(summarizeReadingStats(daily, daily, 'pages', 'day').total).toBe(40);
+    expect(summarizeReadingStats(daily, daily, 'hizbs', 'day').total).toBe(10);
+  });
+
+  it('floors maxValue at 1 so an all-zero window still has a scale', () => {
+    const daily = buildDailyRecords([], { value: 0, date: day(0) }, 0, 7);
+    const stats = summarizeReadingStats(daily, daily, 'hizbs', 'day');
+
+    expect(stats.total).toBe(0);
+    expect(stats.maxValue).toBe(1);
+    // Today is always a record, so the recorded-day average is 0/1.
+    expect(stats.effectiveAvg).toBe(0);
+  });
+
+  it('reports the earliest recorded day as the tracking start', () => {
+    const daily = partialWindow(90, 22);
+    const stats = summarizeReadingStats(daily, daily, 'hizbs', 'day');
+
+    expect(stats.trackingStartedAt).toBe(day(21));
+  });
+
+  it('reports no tracking start when nothing in the window is recorded', () => {
+    const daily = Array.from({ length: 7 }, (_, i) => ({
+      ...record(6 - i),
+      hasRecord: false,
+    }));
+    const stats = summarizeReadingStats(daily, daily, 'hizbs', 'day');
+
+    expect(stats.trackingStartedAt).toBeNull();
+    expect(stats.recordsWithData).toBe(0);
+    // With no recorded days there is nothing to correct the average against.
+    expect(stats.effectiveAvg).toBe(stats.avg);
+  });
+
+  it('handles an empty series without dividing by zero', () => {
+    const stats = summarizeReadingStats([], [], 'hizbs', 'day');
+
+    expect(stats.total).toBe(0);
+    expect(stats.avg).toBe(0);
+    expect(stats.effectiveAvg).toBe(0);
+    expect(stats.maxValue).toBe(1);
+    expect(stats.trackingStartedAt).toBeNull();
+  });
+});

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -14,4 +14,6 @@ export * from './quranMetadataUtils';
 
 export * from './readingChart';
 
+export * from './readingStats';
+
 export * from './triggerHaptic';

--- a/utils/readingChart.ts
+++ b/utils/readingChart.ts
@@ -48,6 +48,7 @@ const toLocalDigits: (n: number) => string = (() => {
 })();
 
 export type GroupBy = 'day' | 'week' | 'month';
+export type ChartMetric = 'hizbs' | 'pages';
 export type ChartLabel = { primary: string; secondary?: string };
 
 /**

--- a/utils/readingStats.ts
+++ b/utils/readingStats.ts
@@ -1,0 +1,202 @@
+import type { DailyReadingRecord } from '@/jotai/atoms';
+
+import { type ChartMetric, daysAgo, type GroupBy } from './readingChart';
+
+/**
+ * Number of daily records collapsed into one bucket per granularity.
+ * `month` is a fixed 30-day window rather than a calendar month so every
+ * bucket in the series covers the same span and stays comparable.
+ */
+const BUCKET_DAYS: Record<Exclude<GroupBy, 'day'>, number> = {
+  week: 7,
+  month: 30,
+};
+
+/** Today's in-progress tracker, before it is rolled into `readingHistory`. */
+export type DailyTrackerSnapshot = { value: number; date: string };
+
+/** The aggregate figures the chart header renders above the bars. */
+export type ReadingStats = {
+  total: number;
+  maxValue: number;
+  avg: number;
+  effectiveAvg: number;
+  recordsWithData: number;
+  trackingStartedAt: string | null;
+};
+
+/**
+ * Builds one record per day for the trailing `period` days, oldest first and
+ * ending with today.
+ *
+ * Days the user has no entry for are padded with zeros and `hasRecord: false`
+ * so the chart can draw them as "not tracked yet" rather than "read nothing".
+ * A stored entry of zero is different: it keeps `hasRecord: true` and counts
+ * towards the recorded-day average.
+ *
+ * Today is always taken from the live tracker rather than history — the
+ * history entry for today is only written when the day rolls over.
+ *
+ * @param history - Persisted daily records, in any order.
+ * @param todayTracker - Today's in-progress hizb count and its date stamp.
+ * @param todayPagesRead - Pages read today, derived from the saved page.
+ * @param period - Length of the window in days.
+ * @returns `period` records ordered oldest to newest.
+ */
+export function buildDailyRecords(
+  history: readonly DailyReadingRecord[],
+  todayTracker: DailyTrackerSnapshot,
+  todayPagesRead: number,
+  period: number,
+): DailyReadingRecord[] {
+  const hizbMap = new Map<string, number>();
+  const pagesMap = new Map<string, number>();
+  // Track which date strings had a real record. Used both to set
+  // `hasRecord` on each daily slot (so the chart can render "no data"
+  // vs "read 0") and to derive `trackingStartedAt` (the earliest date
+  // with a record in the current window).
+  const recordedDates = new Set<string>();
+
+  for (const entry of history) {
+    hizbMap.set(entry.date, entry.hizbsCompleted);
+    pagesMap.set(entry.date, entry.pagesRead ?? 0);
+    recordedDates.add(entry.date);
+  }
+
+  hizbMap.set(todayTracker.date, todayTracker.value);
+  pagesMap.set(todayTracker.date, todayPagesRead);
+  recordedDates.add(todayTracker.date);
+
+  const result: DailyReadingRecord[] = [];
+  for (let i = period - 1; i >= 0; i--) {
+    const dateStr = daysAgo(i);
+    const hasRecord = recordedDates.has(dateStr);
+    result.push({
+      date: dateStr,
+      hizbsCompleted: hasRecord ? (hizbMap.get(dateStr) ?? 0) : 0,
+      pagesRead: hasRecord ? (pagesMap.get(dateStr) ?? 0) : 0,
+      hasRecord,
+    });
+  }
+  return result;
+}
+
+// Sum a slice of daily records into a single bucket. The bucket inherits its
+// `date` from the last day in the slice (the most recent day in the bucket is
+// the most informative label anchor) and computes `weekStart` by walking back
+// `chunk.length - 1` days from that anchor — using the actual chunk length
+// keeps the range accurate for the partial trailing bucket that appears when
+// the period isn't a multiple of the bucket size (e.g. 30 days grouped by
+// week → 4 full weeks + 2 days).
+const aggregateBucket = (
+  daily: readonly DailyReadingRecord[],
+): DailyReadingRecord => {
+  const end = new Date(daily[daily.length - 1].date);
+  const start = new Date(end);
+  start.setDate(end.getDate() - (daily.length - 1));
+  return {
+    date: end.toDateString(),
+    weekStart: start.toDateString(),
+    daysInBucket: daily.length,
+    hizbsCompleted: parseFloat(
+      daily.reduce((s, d) => s + d.hizbsCompleted, 0).toFixed(1),
+    ),
+    pagesRead: daily.reduce((s, d) => s + d.pagesRead, 0),
+    // A bucket counts as having a record if at least one underlying day had
+    // one. An empty bucket (user didn't track at all that week) stays at 0
+    // with hasRecord=false so the chart can render it as "no data" instead
+    // of "read 0".
+    hasRecord: daily.some((d) => d.hasRecord),
+  };
+};
+
+/**
+ * Collapses the daily series into the bars the chart actually renders.
+ *
+ * Buckets are cut from the oldest day forward, so an incomplete period leaves
+ * the *trailing* bucket short; its `daysInBucket` is the real day count and
+ * drives the partial-bucket treatment in `formatLabel` and the chart.
+ *
+ * @param daily - Daily records, oldest first.
+ * @param groupBy - Bar granularity. `'day'` passes the series through.
+ * @returns One record per rendered bar, oldest first.
+ */
+export function groupDailyRecords(
+  daily: readonly DailyReadingRecord[],
+  groupBy: GroupBy,
+): DailyReadingRecord[] {
+  if (groupBy === 'day') return [...daily];
+
+  const size = BUCKET_DAYS[groupBy];
+  const buckets: DailyReadingRecord[] = [];
+  for (let i = 0; i < daily.length; i += size) {
+    const chunk = daily.slice(i, i + size);
+    if (chunk.length > 0) buckets.push(aggregateBucket(chunk));
+  }
+  return buckets;
+}
+
+/**
+ * Reads the charted quantity off a record for the selected metric.
+ *
+ * @param record - A daily record or an aggregated bucket.
+ * @param metric - The unit the chart is currently displaying.
+ * @returns Hizbs or pages, depending on `metric`.
+ */
+export function getMetricValue(
+  record: DailyReadingRecord,
+  metric: ChartMetric,
+): number {
+  return metric === 'pages' ? record.pagesRead : record.hizbsCompleted;
+}
+
+/**
+ * Derives the header figures for the current window.
+ *
+ * `avg` is per rendered bar — per day, per week, or per month — and uses
+ * `grouped.length` as the denominator so a partial trailing bucket doesn't
+ * skew it. `effectiveAvg` differs only in the daily view, where it divides by
+ * the number of *recorded* days: a user who started tracking 22 days ago
+ * should see their 1-hizb/day pace, not 0.24 hizb/day across a 90-day window.
+ * Weekly and monthly buckets already collapse untracked stretches into their
+ * own totals, so `effectiveAvg` falls back to `avg` there.
+ *
+ * @param daily - The ungrouped daily series; carries the `hasRecord` flags.
+ * @param grouped - The rendered bars, from `groupDailyRecords`.
+ * @param metric - The unit the chart is currently displaying.
+ * @param groupBy - Bar granularity.
+ * @returns Totals, averages, recorded-day count, and the tracking start date.
+ */
+export function summarizeReadingStats(
+  daily: readonly DailyReadingRecord[],
+  grouped: readonly DailyReadingRecord[],
+  metric: ChartMetric,
+  groupBy: GroupBy,
+): ReadingStats {
+  const values = grouped.map((d) => getMetricValue(d, metric));
+  // Floor of 1 keeps the y-axis and the bar heights finite on an all-zero
+  // window (nothing to divide by otherwise).
+  const maxValue = Math.max(1, ...values);
+  const total = values.reduce((sum, v) => sum + v, 0);
+  const avg = total / (grouped.length || 1);
+
+  const recordsWithData = daily.filter((d) => d.hasRecord).length;
+  const effectiveAvg =
+    groupBy === 'day' && recordsWithData > 0 ? total / recordsWithData : avg;
+
+  // The earliest recorded date in the current window — `null` when the user
+  // has no records at all (the empty state handles that). Rendered as a small
+  // caption so users who haven't yet filled the full 90-day window know the
+  // chart isn't missing data.
+  const trackingStartedAt =
+    recordsWithData > 0 ? (daily.find((d) => d.hasRecord)?.date ?? null) : null;
+
+  return {
+    total,
+    maxValue,
+    avg,
+    effectiveAvg,
+    recordsWithData,
+    trackingStartedAt,
+  };
+}

--- a/utils/readingStats.ts
+++ b/utils/readingStats.ts
@@ -2,28 +2,27 @@ import type { DailyReadingRecord } from '@/jotai/atoms';
 
 import { type ChartMetric, daysAgo, type GroupBy } from './readingChart';
 
-/**
- * Number of daily records collapsed into one bucket per granularity.
- * `month` is a fixed 30-day window rather than a calendar month so every
- * bucket in the series covers the same span and stays comparable.
- */
-const BUCKET_DAYS: Record<Exclude<GroupBy, 'day'>, number> = {
-  week: 7,
-  month: 30,
-};
+// Number of daily records collapsed into one bucket per granularity. A month
+// is a fixed 30-day window rather than a calendar month so every bucket in the
+// series covers the same span and stays comparable.
+const WEEK_BUCKET_DAYS = 7;
+const MONTH_BUCKET_DAYS = 30;
 
 /** Today's in-progress tracker, before it is rolled into `readingHistory`. */
-export type DailyTrackerSnapshot = { value: number; date: string };
+export interface DailyTrackerSnapshot {
+  value: number;
+  date: string;
+}
 
 /** The aggregate figures the chart header renders above the bars. */
-export type ReadingStats = {
+export interface ReadingStats {
   total: number;
   maxValue: number;
   avg: number;
   effectiveAvg: number;
   recordsWithData: number;
   trackingStartedAt: string | null;
-};
+}
 
 /**
  * Builds one record per day for the trailing `period` days, oldest first and
@@ -127,7 +126,7 @@ export function groupDailyRecords(
 ): DailyReadingRecord[] {
   if (groupBy === 'day') return [...daily];
 
-  const size = BUCKET_DAYS[groupBy];
+  const size = groupBy === 'week' ? WEEK_BUCKET_DAYS : MONTH_BUCKET_DAYS;
   const buckets: DailyReadingRecord[] = [];
   for (let i = 0; i < daily.length; i += size) {
     const chunk = daily.slice(i, i + size);

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  resolve: {
+    alias: [
+      // Mirror the `@/*` path alias from tsconfig.json. Anchored to `@/` so
+      // scoped packages (`@expo/vector-icons`, `@shopify/flash-list`, …)
+      // still resolve to node_modules.
+      { find: /^@\//, replacement: `${import.meta.dirname}/` },
+      // Pure modules under test still sit behind `react-native` imports
+      // (`Platform`, `I18nManager`). The RN entry point is Flow-typed and
+      // cannot be parsed outside Metro, so tests resolve it to the web
+      // implementation. Anchored so `react-native-svg`, `react-native-mmkv`,
+      // and friends are left alone.
+      { find: /^react-native$/, replacement: 'react-native-web' },
+    ],
+  },
+});


### PR DESCRIPTION
## Description

Adds automated tests for the reading tracker's daily, weekly and monthly statistics, covering
incomplete periods, days with zero pages, and transitions between days.

The calculations lived inside `useReadingChartData` as module-private helpers and inline
`useMemo` bodies, so they could only be reached by mounting the hook against MMKV-backed Jotai
atoms. The first commit extracts them to `utils/readingStats.ts` as pure functions
(`buildDailyRecords`, `groupDailyRecords`, `getMetricValue`, `summarizeReadingStats`); the hook
keeps its public API and return shape and is now only the atom wiring. The second commit adds
the tests and a `vitest.config.mts` supplying the `@/` alias and mapping `react-native` to
`react-native-web`.

To confirm the extraction changed no behavior, I ran the pre-refactor implementation and the new
one over 8640 randomized scenarios — 8 date anchors spanning month, year, leap-day and DST
boundaries, with sparse histories, zero-value days, records missing `pagesRead`, duplicate dates
and out-of-window entries — and deep-compared every returned field. No differences.

Fixes #152

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Style update (formatting, renaming)
- [x] ♻️ Code refactoring
- [x] ✅ Test update (adding or updating tests)
- [ ] 🔧 DevOps update (CI/CD, build config)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have updated the documentation if needed — no update needed; `docs/tracker.md` describes
      behavior and no behavior changed
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

n/a — no user-visible change. The refactor is behavior-preserving (see the differential run
above) and the rest is test code, so there is no before/after to show. The tracker screen renders
identically on `develop` and on this branch with the same seeded history.

Local gate:

```
yarn format:check   All matched files use Prettier code style!
yarn lint           clean
yarn type-check     clean
yarn test           52 passed (2 files)
yarn test:coverage  94.23% stmts | 86.48% branch | 95.5% lines
yarn web:export     Exported: dist
```

Platforms tested: **Web**. Not exercised on iOS or Android.

## Additional Context

n/a
