### PR TITLE
fix(search): make advanced search options readable in dark mode

### DIFF
--- a/components/SearchAdvancedOptions.tsx
+++ b/components/SearchAdvancedOptions.tsx
@@ -3,6 +3,7 @@ import { Modal, Pressable, ScrollView, StyleSheet, View } from 'react-native';
 
 import { Feather } from '@expo/vector-icons';
 
+import { useColors } from '@/hooks';
 import { SearchOptions } from '@/types';
 
 import { ThemedButton } from './ThemedButton';
@@ -19,6 +20,14 @@ export function SearchAdvancedOptions({
   toggleOption,
 }: SearchAdvancedOptionsProps) {
   const [modalVisible, setModalVisible] = useState(false);
+  const { cardColor, iconColor, textColor } = useColors();
+
+  // The pill surface must follow the theme; a hardcoded white background left the
+  // themed label text invisible in dark mode.
+  const themedOption = {
+    backgroundColor: cardColor,
+    borderColor: iconColor,
+  };
 
   return (
     <ThemedView style={styles.container}>
@@ -151,6 +160,7 @@ export function SearchAdvancedOptions({
           <Pressable
             style={[
               styles.optionButton,
+              themedOption,
               advancedOptions.lemma && styles.optionActive,
               advancedOptions.isRegex && styles.optionDisabled,
             ]}
@@ -170,6 +180,7 @@ export function SearchAdvancedOptions({
           <Pressable
             style={[
               styles.optionButton,
+              themedOption,
               advancedOptions.root && styles.optionActive,
               advancedOptions.isRegex && styles.optionDisabled,
             ]}
@@ -189,6 +200,7 @@ export function SearchAdvancedOptions({
           <Pressable
             style={[
               styles.optionButton,
+              themedOption,
               advancedOptions.fuzzy && styles.optionActive,
               advancedOptions.isRegex && styles.optionDisabled,
             ]}
@@ -208,6 +220,7 @@ export function SearchAdvancedOptions({
           <Pressable
             style={[
               styles.optionButton,
+              themedOption,
               advancedOptions.semantic && styles.optionActive,
               advancedOptions.isRegex && styles.optionDisabled,
             ]}
@@ -231,6 +244,7 @@ export function SearchAdvancedOptions({
           <Pressable
             style={[
               styles.regexButton,
+              { backgroundColor: cardColor },
               advancedOptions.isRegex && styles.regexActive,
             ]}
             onPress={() => toggleOption('isRegex')}
@@ -249,7 +263,7 @@ export function SearchAdvancedOptions({
               Regex (تعابير نمطية)
             </ThemedText>
           </Pressable>
-          <ThemedText style={styles.regexHint}>
+          <ThemedText style={[styles.regexHint, { color: textColor }]}>
             يلغي تفعيل الخيارات الأخرى
           </ThemedText>
         </View>
@@ -299,8 +313,6 @@ const styles = StyleSheet.create({
     paddingVertical: 8,
     borderRadius: 20,
     borderWidth: 1,
-    borderColor: '#ddd',
-    backgroundColor: '#fff',
   },
   optionActive: {
     backgroundColor: '#e3f2fd',
@@ -308,8 +320,6 @@ const styles = StyleSheet.create({
   },
   optionDisabled: {
     opacity: 0.5,
-    backgroundColor: '#f5f5f5',
-    borderColor: '#eee',
   },
   optionActiveText: {
     color: '#1976d2',
@@ -317,7 +327,7 @@ const styles = StyleSheet.create({
     fontSize: 13,
   },
   optionDisabledText: {
-    color: '#999',
+    opacity: 0.6,
   },
   divider: {
     height: 1,
@@ -337,7 +347,6 @@ const styles = StyleSheet.create({
     borderRadius: 24,
     borderWidth: 1.5,
     borderColor: '#d32f2f',
-    backgroundColor: '#fff',
   },
   regexActive: {
     backgroundColor: '#d32f2f',
@@ -352,7 +361,7 @@ const styles = StyleSheet.create({
   },
   regexHint: {
     fontSize: 11,
-    color: '#666',
+    opacity: 0.7,
   },
   // Modal Styles
   modalOverlay: {


### PR DESCRIPTION
السلام عليكم

Fixes the dark-mode readability problem reported in #166.

### The problem

`components/SearchAdvancedOptions.tsx` hardcoded `backgroundColor: '#fff'` on the option pills while their labels use `<ThemedText>`, which resolves to `text: '#EDEDED'` in dark mode (`constants/Colors.ts`). That put near-white text on a white pill — about 1.1:1 contrast, effectively invisible.

The Regex button had the same hardcoded white surface. Its label is a fixed red so it stayed readable, but it rendered as a white shape on a dark screen and no longer matched the pills next to it.

This came in with 9efb5a0; before that commit `optionButton` had no `backgroundColor` and inherited the themed background correctly.

### The change

- Both surfaces now take their background from `useColors()` (`cardColor`), so they follow the active theme.
- `optionDisabled` no longer forces a light grey surface; it keeps the `opacity: 0.5` it already had.
- `optionDisabledText` (`#999`) and `regexHint` (`#666`) use opacity instead of hardcoded greys, so they follow the theme too.
- `optionActive` is untouched — `#1976d2` on `#e3f2fd` reads fine in both themes.
- The help modal deliberately keeps its white background: its text colours are hardcoded dark, so it is legible in either theme.

Light mode is visually unchanged: `cardColor` is `#FFFFFF` there, which is what the pills were hardcoded to anyway.

### Verification

`yarn type-check`, `yarn lint` and `yarn web:export` all pass. Verified in the browser in dark mode.

Before/after screenshots are in the comments on #166, and I will add them here as well.

Closes #166
